### PR TITLE
Workflow zur eines Nightly und Push zu Docker Hub

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,12 @@
 name: Nightly Build and Push
-# This workflow builds and pushes a Docker image to Docker Hub on a nightly schedule.
-# It runs at 2 AM UTC and can also be triggered manually.
-# The image is tagged with 'nightly' and pushed to the Docker Hub repository.
-# The workflow uses secrets for Docker Hub credentials, which should be set in the repository settings.
-# The image is built from the Dockerfile in the root of the repository.
+# This workflow builds and pushes a Docker image to GitHub Container Registry
+# and optionally to Docker Hub.
+# It runs nightly at 2 AM UTC and can also be triggered manually.
+# The image is tagged with "nightly" and the repository owner is converted to lowercase.
+# The workflow uses the GITHUB_TOKEN secret for authentication with GitHub Container Registry.
+# Uncomment the Docker Hub section if you want to push to Docker Hub as well.
+# The Docker Hub credentials should be stored in the repository secrets as DOCKER_USERNAME and DOCKER_PASSWORD.
+# The workflow is triggered on a schedule and can also be run manually.
 
 on:
   schedule: # runs on the default branch: master
@@ -33,4 +36,3 @@ jobs:
 #        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 #      - name: Push image to Docker Hub
 #        run: docker push ${{ secrets.DOCKER_USERNAME }}/eos_connect:nightly
-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,8 +18,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Build image
         run: docker build -t ${{ secrets.DOCKER_USERNAME }}/eos_connect:nightly .
-      - name: Log in to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      - name: Push image to Docker Hub
-        run: docker push ${{ secrets.DOCKER_USERNAME }}/eos_connect:nightly
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push Docker image to GitHub Container Registry
+        run: docker push ghcr.io/${{ github.repository_owner }}/eos_connect:latest
+#      - name: Log in to Docker Hub
+#        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+#      - name: Push image to Docker Hub
+#        run: docker push ${{ secrets.DOCKER_USERNAME }}/eos_connect:nightly
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,9 @@
 name: Nightly Build and Push
+# This workflow builds and pushes a Docker image to Docker Hub on a nightly schedule.
+# It runs at 2 AM UTC and can also be triggered manually.
+# The image is tagged with 'nightly' and pushed to the Docker Hub repository.
+# The workflow uses secrets for Docker Hub credentials, which should be set in the repository settings.
+# The image is built from the Dockerfile in the root of the repository.
 
 on:
   schedule: # runs on the default branch: master
@@ -12,9 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build image
-        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/eos_connect_test:nightly .
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/eos_connect:nightly .
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
       - name: Push image to Docker Hub
-        run: docker push ${{ secrets.DOCKER_USERNAME }}/eos_connect_test:nightly
+        run: docker push ${{ secrets.DOCKER_USERNAME }}/eos_connect:nightly
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Build 
+name: Nightly Build
 
 on:
   schedule: # runs on the default branch: master

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build image
-        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/eos_connect_test:nightly
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/eos_connect_test:nightly .
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
       - name: Push image to Docker Hub

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Build image
-        run: docker build -t ${{ env.owner }}/eos_connect:nightly .
+        run: docker build -t ghcr.io/${{ env.owner }}/eos_connect:nightly .
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Push Docker image to GitHub Container Registry
-        run: docker push ghcr.io/${{ github.repository_owner }}/eos_connect:latest
+        run: docker push ghcr.io/${{ github.repository_owner | toLowerCase }}/eos_connect:nightly
 #      - name: Log in to Docker Hub
 #        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 #      - name: Push image to Docker Hub

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Build
+name: Nightly Build 
 
 on:
   schedule: # runs on the default branch: master

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,36 +1,20 @@
-name: Docker Image CI
+name: Nightly Build
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-
+  schedule: # runs on the default branch: master
+  - cron: "0 2 * * *" # run at 2 AM UTC
+  workflow_dispatch: # allows manual triggering of the workflow
+  
 jobs:
-
-  build:
-
+  publish_image:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag eos_connect_v0.0.${{github.run_number}}
-    - name: Save Docker image to file
-      run: docker save eos_connect_v0.0.${{github.run_number}} -o eos_connect_v0.0.${{github.run_number}}
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: eos_connect_v0.0.${{github.run_number}}
-        path: |
-          eos_connect_v0.0.${{github.run_number}}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/eos_connect_test:nightly
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: Push image to Docker Hub
+        run: docker push ${{ secrets.DOCKER_USERNAME }}/eos_connect_test:nightly
 
-    - uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "v0.0.${{github.run_number}}"
-        draft: false
-        prerelease: false
-        title: "eos_connect dockerimage v0.0.${{github.run_number}}"
-        files: |
-          eos_connect_v0.0.${{github.run_number}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,8 +20,10 @@ jobs:
         run: docker build -t ${{ secrets.DOCKER_USERNAME }}/eos_connect:nightly .
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Convert repository owner to lowercase
+        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
       - name: Push Docker image to GitHub Container Registry
-        run: docker push ghcr.io/${{ github.repository_owner | toLowerCase }}/eos_connect:nightly
+        run: docker push ghcr.io/${{ env.owner }}/eos_connect:nightly
 #      - name: Log in to Docker Hub
 #        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 #      - name: Push image to Docker Hub

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,14 +16,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Build image
-        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/eos_connect:nightly .
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Convert repository owner to lowercase
         run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Build image
+        run: docker build -t ${{ env.owner }}/eos_connect:nightly .
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Push Docker image to GitHub Container Registry
         run: docker push ghcr.io/${{ env.owner }}/eos_connect:nightly
+
 #      - name: Log in to Docker Hub
 #        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 #      - name: Push image to Docker Hub

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,36 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag eos_connect_v0.0.${{github.run_number}}
+    - name: Save Docker image to file
+      run: docker save eos_connect_v0.0.${{github.run_number}} -o eos_connect_v0.0.${{github.run_number}}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: eos_connect_v0.0.${{github.run_number}}
+        path: |
+          eos_connect_v0.0.${{github.run_number}}
+
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "v0.0.${{github.run_number}}"
+        draft: false
+        prerelease: false
+        title: "eos_connect dockerimage v0.0.${{github.run_number}}"
+        files: |
+          eos_connect_v0.0.${{github.run_number}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Build
+name: Nightly Build and Push
 
 on:
   schedule: # runs on the default branch: master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
-version: '3.8'
-
 services:
   eos_connect:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/wolfimbusch/eos_connect:nightly
     ports:
       - "8081:8081"
     volumes:

--- a/src/interfaces/load_interface.py
+++ b/src/interfaces/load_interface.py
@@ -224,8 +224,8 @@ class LoadInterface:
         load_profile = []
         current_hour = start_time
 
-        current_hour = datetime.strptime("18.03.2025 11:00", "%d.%m.%Y %H:%M")
-        end_time = current_hour + timedelta(hours=tgt_duration)
+        # current_hour = datetime.strptime("18.03.2025 11:00", "%d.%m.%Y %H:%M")
+        # end_time = current_hour + timedelta(hours=tgt_duration)
 
         # check car load data for W or kW
         car_load_data = self.fetch_historical_energy_data_from_homeassistant(


### PR DESCRIPTION
This workflow builds and pushes a Docker image to Docker Hub on a nightly schedule.
It runs at 2 AM UTC and can also be triggered manually.
The image is tagged with 'nightly' and pushed to the Docker Hub repository.
The workflow uses secrets for Docker Hub credentials, which should be set in the repository settings.
The image is built from the Dockerfile in the root of the repository.