### PR TITLE
feature: closes #38 openHAB: Extension of the load data range to a configurable value between 2 days and 2 weeks

### DIFF
--- a/src/CONFIG_README.md
+++ b/src/CONFIG_README.md
@@ -242,7 +242,7 @@ The `mqtt` section allows you to configure the MQTT broker and Home Assistant MQ
 # Load configuration
 load:
   source: default  # Data source for load power - openhab, homeassistant, default (using a static load profile)
-  url: http://homeassistant:8123 # URL for openhab or homeassistant (e.g. http://openhab:7070 or http://homeassistant:8123)
+  url: http://homeassistant:8123 # URL for openhab or homeassistant (e.g. http://openhab:8080 or http://homeassistant:8123)
   load_sensor: Load_Power # item / entity for load power data in watts
   car_charge_load_sensor: Wallbox_Power # item / entity for wallbox power data in watts
   access_token: abc123 # access token for homeassistant (optional)

--- a/src/config.py
+++ b/src/config.py
@@ -141,7 +141,7 @@ class ConfigManager:
         )
         config["load"].yaml_add_eol_comment(
             "URL for openhab or homeassistant"+
-            " (e.g. http://openhab:7070 or http://homeassistant:8123)",
+            " (e.g. http://openhab:8080 or http://homeassistant:8123)",
             "url",
         )
         config["load"].yaml_add_eol_comment(
@@ -190,7 +190,7 @@ class ConfigManager:
         )
         config["battery"].yaml_add_eol_comment(
             "URL for openhab or homeassistant"+
-            " (e.g. http://openhab:7070 or http://homeassistant:8123)",
+            " (e.g. http://openhab:8080 or http://homeassistant:8123)",
             "url",
         )
         config["battery"].yaml_add_eol_comment(

--- a/src/eos_connect.py
+++ b/src/eos_connect.py
@@ -427,6 +427,178 @@ def create_optimize_request():
     return payload
 
 
+def setting_control_data(ac_charge_demand_rel, dc_charge_demand_rel, discharge_allowed):
+    """
+    Process the optimized response from EOS and update the load interface.
+
+    Args:
+        ac_charge_demand_rel (float): The relative AC charge demand.
+        dc_charge_demand_rel (float): The relative DC charge demand.
+        discharge_allowed (bool): Whether discharge is allowed (True/False).
+    """
+    base_control.set_current_ac_charge_demand(ac_charge_demand_rel)
+    base_control.set_current_dc_charge_demand(dc_charge_demand_rel)
+    base_control.set_current_discharge_allowed(bool(discharge_allowed))
+    mqtt_interface.update_publish_topics(
+        {
+            "control/eos_ac_charge_demand": {
+                "value": base_control.get_current_ac_charge_demand()
+            },
+            "control/eos_dc_charge_demand": {
+                "value": base_control.get_current_dc_charge_demand()
+            },
+            "control/eos_discharge_allowed": {
+                "value": base_control.get_current_discharge_allowed()
+            },
+        }
+    )
+    # set the current battery state of charge
+    base_control.set_current_battery_soc(battery_interface.get_current_soc())
+    # getting the current charging state from evcc
+    base_control.set_current_evcc_charging_state(evcc_interface.get_charging_state())
+    base_control.set_current_evcc_charging_mode(evcc_interface.get_charging_mode())
+
+
+def change_control_state():
+    """
+    Adjusts the control state of the inverter based on the current overall state.
+
+    This function checks the current overall state of the inverter and performs
+    the corresponding action. The possible states and their actions are:
+    - MODE_CHARGE_FROM_GRID (state 0): Sets the inverter to charge from the grid
+      with the specified AC charge demand.
+    - MODE_AVOID_DISCHARGE (state 1): Sets the inverter to avoid discharge.
+    - MODE_DISCHARGE_ALLOWED (state 2): Sets the inverter to allow discharge.
+    - Uninitialized state (state < 0): Logs a warning indicating that the inverter
+      mode is not initialized yet.
+
+    Returns:
+        bool: True if the state was changed recently and an action was performed,
+              False otherwise.
+    """
+    inverter_en = False
+    if config_manager.config["inverter"]["type"] == "fronius_gen24":
+        inverter_en = True
+
+    current_overall_state = base_control.get_current_overall_state_number()
+    current_overall_state_text = base_control.get_current_overall_state()
+
+    mqtt_interface.update_publish_topics(
+        {
+            "control/overall_state": {
+                "value": base_control.get_current_overall_state_number()
+            },
+            "optimization/state": {
+                "value": optimization_scheduler.get_current_state()["request_state"]
+            },
+            # "control/override_remain_time": {"value": "01:00"},
+            # "control/override_charge_power": {
+            #     "value": base_control.get_current_ac_charge_demand()
+            # },
+            "control/override_active": {
+                "value": base_control.get_override_active_and_endtime()[0]
+            },
+            "control/override_end_time": {
+                "value": (
+                    datetime.fromtimestamp(
+                        base_control.get_override_active_and_endtime()[1], time_zone
+                    )
+                ).isoformat()
+            },
+            "battery/soc": {"value": battery_interface.get_current_soc()},
+            "battery/remaining_energy": {
+                "value": battery_interface.get_current_usable_capacity()
+            },
+            "battery/dyn_max_charge_power": {
+                "value": battery_interface.get_max_charge_power()
+            },
+            "status": {"value": "online"},
+        }
+    )
+
+    # get the current ac/dc charge demand and for setting to inverter according
+    # to the max dynamic charge power of the battery based on SOC
+    tgt_ac_charge_power = min(
+        base_control.get_current_ac_charge_demand(),
+        round(battery_interface.get_max_charge_power()),
+    )
+    tgt_dc_charge_power = min(
+        base_control.get_current_dc_charge_demand(),
+        round(battery_interface.get_max_charge_power()),
+    )
+
+    base_control.set_current_bat_charge_max(
+        max(tgt_ac_charge_power, tgt_dc_charge_power)
+    )
+
+    # Check if the overall state of the inverter was changed recently
+    if base_control.was_overall_state_changed_recently(180):
+        logger.debug("[Main] Overall state changed recently")
+        # MODE_CHARGE_FROM_GRID
+        if current_overall_state == 0:
+            if inverter_en:
+                inverter_interface.set_mode_force_charge(tgt_ac_charge_power)
+            logger.info(
+                "[Main] Inverter mode set to %s with %s W (_____|||||_____)",
+                current_overall_state_text,
+                tgt_ac_charge_power,
+            )
+        # MODE_AVOID_DISCHARGE
+        elif current_overall_state == 1:
+            if inverter_en:
+                inverter_interface.set_mode_avoid_discharge()
+            logger.info(
+                "[Main] Inverter mode set to %s (_____-----_____)",
+                current_overall_state_text,
+            )
+        # MODE_DISCHARGE_ALLOWED
+        elif current_overall_state == 2:
+            if inverter_en:
+                inverter_interface.api_set_max_pv_charge_rate(tgt_dc_charge_power)
+                inverter_interface.set_mode_allow_discharge()
+            logger.info(
+                "[Main] Inverter mode set to %s (_____+++++_____)",
+                current_overall_state_text,
+            )
+        # MODE_AVOID_DISCHARGE_EVCC_FAST
+        elif current_overall_state == 3:
+            if inverter_en:
+                inverter_interface.set_mode_avoid_discharge()
+            logger.info(
+                "[Main] Inverter mode set to %s (_____+---+_____)",
+                current_overall_state_text,
+            )
+        # MODE_DISCHARGE_ALLOWED_EVCC_PV
+        elif current_overall_state == 4:
+            if inverter_en:
+                inverter_interface.api_set_max_pv_charge_rate(tgt_dc_charge_power)
+                inverter_interface.set_mode_allow_discharge()
+            logger.info(
+                "[Main] Inverter mode set to %s (_____-+++-_____)",
+                current_overall_state_text,
+            )
+        # MODE_DISCHARGE_ALLOWED_EVCC_MIN_PV
+        elif current_overall_state == 5:
+            if inverter_en:
+                inverter_interface.api_set_max_pv_charge_rate(tgt_dc_charge_power)
+                inverter_interface.set_mode_allow_discharge()
+            logger.info(
+                "[Main] Inverter mode set to %s (_____+-+-+_____)",
+                current_overall_state_text,
+            )
+        elif current_overall_state < 0:
+            logger.warning("[Main] Inverter mode not initialized yet")
+        return True
+
+    # Log the current state if no recent changes were made
+    logger.info(
+        "[Main] Overall state not changed recently"
+        + " - remaining in current state: %s  (_____OOOOO_____)",
+        current_overall_state_text,
+    )
+    return False
+
+
 class OptimizationScheduler:
     """
     A scheduler class that manages the periodic execution of an optimization process
@@ -727,178 +899,6 @@ class OptimizationScheduler:
 optimization_scheduler = OptimizationScheduler(
     config_manager.config["refresh_time"] * 60  # convert to seconds
 )
-
-
-def setting_control_data(ac_charge_demand_rel, dc_charge_demand_rel, discharge_allowed):
-    """
-    Process the optimized response from EOS and update the load interface.
-
-    Args:
-        ac_charge_demand_rel (float): The relative AC charge demand.
-        dc_charge_demand_rel (float): The relative DC charge demand.
-        discharge_allowed (bool): Whether discharge is allowed (True/False).
-    """
-    base_control.set_current_ac_charge_demand(ac_charge_demand_rel)
-    base_control.set_current_dc_charge_demand(dc_charge_demand_rel)
-    base_control.set_current_discharge_allowed(bool(discharge_allowed))
-    mqtt_interface.update_publish_topics(
-        {
-            "control/eos_ac_charge_demand": {
-                "value": base_control.get_current_ac_charge_demand()
-            },
-            "control/eos_dc_charge_demand": {
-                "value": base_control.get_current_dc_charge_demand()
-            },
-            "control/eos_discharge_allowed": {
-                "value": base_control.get_current_discharge_allowed()
-            },
-        }
-    )
-    # set the current battery state of charge
-    base_control.set_current_battery_soc(battery_interface.get_current_soc())
-    # getting the current charging state from evcc
-    base_control.set_current_evcc_charging_state(evcc_interface.get_charging_state())
-    base_control.set_current_evcc_charging_mode(evcc_interface.get_charging_mode())
-
-
-def change_control_state():
-    """
-    Adjusts the control state of the inverter based on the current overall state.
-
-    This function checks the current overall state of the inverter and performs
-    the corresponding action. The possible states and their actions are:
-    - MODE_CHARGE_FROM_GRID (state 0): Sets the inverter to charge from the grid
-      with the specified AC charge demand.
-    - MODE_AVOID_DISCHARGE (state 1): Sets the inverter to avoid discharge.
-    - MODE_DISCHARGE_ALLOWED (state 2): Sets the inverter to allow discharge.
-    - Uninitialized state (state < 0): Logs a warning indicating that the inverter
-      mode is not initialized yet.
-
-    Returns:
-        bool: True if the state was changed recently and an action was performed,
-              False otherwise.
-    """
-    inverter_en = False
-    if config_manager.config["inverter"]["type"] == "fronius_gen24":
-        inverter_en = True
-
-    current_overall_state = base_control.get_current_overall_state_number()
-    current_overall_state_text = base_control.get_current_overall_state()
-
-    mqtt_interface.update_publish_topics(
-        {
-            "control/overall_state": {
-                "value": base_control.get_current_overall_state_number()
-            },
-            "optimization/state": {
-                "value": optimization_scheduler.get_current_state()["request_state"]
-            },
-            # "control/override_remain_time": {"value": "01:00"},
-            # "control/override_charge_power": {
-            #     "value": base_control.get_current_ac_charge_demand()
-            # },
-            "control/override_active": {
-                "value": base_control.get_override_active_and_endtime()[0]
-            },
-            "control/override_end_time": {
-                "value": (
-                    datetime.fromtimestamp(
-                        base_control.get_override_active_and_endtime()[1], time_zone
-                    )
-                ).isoformat()
-            },
-            "battery/soc": {"value": battery_interface.get_current_soc()},
-            "battery/remaining_energy": {
-                "value": battery_interface.get_current_usable_capacity()
-            },
-            "battery/dyn_max_charge_power": {
-                "value": battery_interface.get_max_charge_power()
-            },
-            "status": {"value": "online"},
-        }
-    )
-
-    # get the current ac/dc charge demand and for setting to inverter according
-    # to the max dynamic charge power of the battery based on SOC
-    tgt_ac_charge_power = min(
-        base_control.get_current_ac_charge_demand(),
-        round(battery_interface.get_max_charge_power()),
-    )
-    tgt_dc_charge_power = min(
-        base_control.get_current_dc_charge_demand(),
-        round(battery_interface.get_max_charge_power()),
-    )
-
-    base_control.set_current_bat_charge_max(
-        max(tgt_ac_charge_power, tgt_dc_charge_power)
-    )
-
-    # Check if the overall state of the inverter was changed recently
-    if base_control.was_overall_state_changed_recently(180):
-        logger.debug("[Main] Overall state changed recently")
-        # MODE_CHARGE_FROM_GRID
-        if current_overall_state == 0:
-            if inverter_en:
-                inverter_interface.set_mode_force_charge(tgt_ac_charge_power)
-            logger.info(
-                "[Main] Inverter mode set to %s with %s W (_____|||||_____)",
-                current_overall_state_text,
-                tgt_ac_charge_power,
-            )
-        # MODE_AVOID_DISCHARGE
-        elif current_overall_state == 1:
-            if inverter_en:
-                inverter_interface.set_mode_avoid_discharge()
-            logger.info(
-                "[Main] Inverter mode set to %s (_____-----_____)",
-                current_overall_state_text,
-            )
-        # MODE_DISCHARGE_ALLOWED
-        elif current_overall_state == 2:
-            if inverter_en:
-                inverter_interface.api_set_max_pv_charge_rate(tgt_dc_charge_power)
-                inverter_interface.set_mode_allow_discharge()
-            logger.info(
-                "[Main] Inverter mode set to %s (_____+++++_____)",
-                current_overall_state_text,
-            )
-        # MODE_AVOID_DISCHARGE_EVCC_FAST
-        elif current_overall_state == 3:
-            if inverter_en:
-                inverter_interface.set_mode_avoid_discharge()
-            logger.info(
-                "[Main] Inverter mode set to %s (_____+---+_____)",
-                current_overall_state_text,
-            )
-        # MODE_DISCHARGE_ALLOWED_EVCC_PV
-        elif current_overall_state == 4:
-            if inverter_en:
-                inverter_interface.api_set_max_pv_charge_rate(tgt_dc_charge_power)
-                inverter_interface.set_mode_allow_discharge()
-            logger.info(
-                "[Main] Inverter mode set to %s (_____-+++-_____)",
-                current_overall_state_text,
-            )
-        # MODE_DISCHARGE_ALLOWED_EVCC_MIN_PV
-        elif current_overall_state == 5:
-            if inverter_en:
-                inverter_interface.api_set_max_pv_charge_rate(tgt_dc_charge_power)
-                inverter_interface.set_mode_allow_discharge()
-            logger.info(
-                "[Main] Inverter mode set to %s (_____+-+-+_____)",
-                current_overall_state_text,
-            )
-        elif current_overall_state < 0:
-            logger.warning("[Main] Inverter mode not initialized yet")
-        return True
-
-    # Log the current state if no recent changes were made
-    logger.info(
-        "[Main] Overall state not changed recently"
-        + " - remaining in current state: %s  (_____OOOOO_____)",
-        current_overall_state_text,
-    )
-    return False
 
 
 # web server

--- a/src/interfaces/load_interface.py
+++ b/src/interfaces/load_interface.py
@@ -36,18 +36,37 @@ class LoadInterface:
         self.time_zone = timezone
 
     # get load data from url persistance source
-    def fetch_energy_data_from_openhab(self, openhab_item_url, start_time, end_time):
+    def __fetch_historical_energy_data_from_openhab(
+        self, openhab_item, start_time, end_time
+    ):
         """
         Fetch energy data from the specified OpenHAB item URL within the given time range.
         """
-        if openhab_item_url == "":
+        if openhab_item == "":
             return {"data": []}
-        openhab_item_url = self.url + "/rest/persistence/items/" + self.load_sensor
+        openhab_item_url = self.url + "/rest/persistence/items/" + openhab_item
         params = {"starttime": start_time.isoformat(), "endtime": end_time.isoformat()}
         try:
             response = requests.get(openhab_item_url, params=params, timeout=10)
             response.raise_for_status()
-            return response.json()
+            # logger.debug(
+            #     "[LOAD-IF] OPENHAB - Fetched data from %s to %s",
+            #     start_time.isoformat(),
+            #     end_time.isoformat()
+            # )
+
+            historical_data = (response.json())["data"]
+            # Extract only 'state' and 'last_updated' from the historical data
+            filtered_data = [
+                {
+                    "state": entry["state"],
+                    "last_updated": datetime.utcfromtimestamp(
+                        entry["time"] / 1000
+                    ).isoformat(),
+                }
+                for entry in historical_data
+            ]
+            return filtered_data
         except requests.exceptions.Timeout:
             logger.error(
                 "[LOAD-IF] OPENHAB - Request timed out while fetching energy data."
@@ -59,7 +78,7 @@ class LoadInterface:
             )
             return {"data": []}
 
-    def fetch_historical_energy_data_from_homeassistant(
+    def __fetch_historical_energy_data_from_homeassistant(
         self, entity_id, start_time, end_time
     ):
         """
@@ -117,7 +136,7 @@ class LoadInterface:
             )
             return []
 
-    def process_energy_data(self, data):
+    def __process_energy_data(self, data):
         """
         Processes energy data to calculate the average energy consumption based on timestamps.
         """
@@ -135,6 +154,9 @@ class LoadInterface:
                 current_time = datetime.fromisoformat(data["data"][i]["last_updated"])
                 next_time = datetime.fromisoformat(data["data"][i + 1]["last_updated"])
             except (ValueError, KeyError):
+                logger.error(
+                    "[LOAD-IF] Error processing energy data: %s", data["data"][i]
+                )
                 continue
 
             duration = (next_time - current_time).total_seconds()
@@ -154,161 +176,167 @@ class LoadInterface:
             return round(total_energy / total_duration, 4)
         return 0
 
-    def create_load_profile_openhab_from_last_days(self, tgt_duration, start_time=None):
-        """
-        Creates a load profile for energy consumption over the last `tgt_duration` hours.
+    # def create_load_profile_openhab_from_last_days(self, tgt_duration, start_time=None):
+    #     """
+    #     Creates a load profile for energy consumption over the last `tgt_duration` hours.
 
-        The function calculates the energy consumption for each hour from the current hour
-        going back `tgt_duration` hours. It fetches energy data for base load and additional loads,
-        processes the data, and sums the energy values. If the total energy for an hour is zero,
-        it skips that hour. The resulting load profile is a list of energy consumption values
-        for each hour.
+    #     The function calculates the energy consumption for each hour from the current hour
+    #     going back `tgt_duration` hours. It fetches energy data for base load and additional loads,
+    #     processes the data, and sums the energy values. If the total energy for an hour is zero,
+    #     it skips that hour. The resulting load profile is a list of energy consumption values
+    #     for each hour.
 
-        """
-        logger.info("[LOAD-IF] Creating load profile from openhab ...")
-        current_time = datetime.now(self.time_zone).replace(
-            minute=0, second=0, microsecond=0
-        )
-        if start_time is None:
-            start_time = current_time.replace(
-                hour=0, minute=0, second=0, microsecond=0
-            ) - timedelta(hours=tgt_duration)
-            end_time = start_time + timedelta(hours=tgt_duration)
-        else:
-            start_time = current_time - timedelta(hours=tgt_duration)
-            end_time = current_time
+    #     """
+    #     logger.info("[LOAD-IF] Creating load profile from openhab ...")
+    #     current_time = datetime.now(self.time_zone).replace(
+    #         minute=0, second=0, microsecond=0
+    #     )
+    #     if start_time is None:
+    #         start_time = current_time.replace(
+    #             hour=0, minute=0, second=0, microsecond=0
+    #         ) - timedelta(hours=tgt_duration)
+    #         end_time = start_time + timedelta(hours=tgt_duration)
+    #     else:
+    #         start_time = current_time - timedelta(hours=tgt_duration)
+    #         end_time = current_time
 
-        load_profile = []
-        current_hour = start_time
+    #     load_profile = []
+    #     current_hour = start_time
 
-        while current_hour < end_time:
-            next_hour = current_hour + timedelta(hours=1)
-            # logger.debug("[LOAD-IF] Fetching data for %s to %s",current_hour, next_hour)
+    #     while current_hour < end_time:
+    #         next_hour = current_hour + timedelta(hours=1)
+    #         # logger.debug("[LOAD-IF] Fetching data for %s to %s",current_hour, next_hour)
 
-            energy_data = self.fetch_energy_data_from_openhab(
-                self.url, current_hour, next_hour
-            )
-            energy = self.process_energy_data(energy_data)
-            if energy == 0:
-                current_hour += timedelta(hours=1)
-                continue
+    #         energy_data = self.__fetch_historical_energy_data_from_openhab(
+    #             self.load_sensor, current_hour, next_hour
+    #         )
+    #         energy = self.__process_energy_data(energy_data)
+    #         if energy == 0:
+    #             logger.warning(
+    #                 "[LOAD-IF] load = 0 ... Energy for %s: %5.1f Wh",
+    #                 current_hour,
+    #                 round(energy, 1),
+    #             )
+    #             # current_hour += timedelta(hours=1)
+    #             # continue
 
-            energy_sum = energy
-            # easy workaround to prevent car charging energy data in the standard load profile
-            if energy_sum > 10800:
-                energy_sum = energy_sum - 10800
-            elif energy_sum > 9200:
-                energy_sum = energy_sum - 9200
+    #         energy_sum = abs(energy)
 
-            load_profile.append(energy_sum)
-            logger.debug("[LOAD-IF] Energy for %s: %s", current_hour, energy_sum)
+    #         load_profile.append(energy_sum)
+    #         logger.debug("[LOAD-IF] Energy for %s: %s", current_hour, energy_sum)
 
-            current_hour += timedelta(hours=1)
-        logger.info("[LOAD-IF] Load profile created successfully.")
-        return load_profile
+    #         current_hour += timedelta(hours=1)
+    #     logger.info("[LOAD-IF] Load profile created successfully.")
+    #     return load_profile
 
-    def create_load_profile_homeassistant_from_last_days(
-        self, tgt_duration, start_time=None
-    ):
-        """
-        Creates a load profile for energy consumption over the last `tgt_duration` hours.
+    # def create_load_profile_homeassistant_from_last_days(
+    #     self, tgt_duration, start_time=None
+    # ):
+    #     """
+    #     Creates a load profile for energy consumption over the last `tgt_duration` hours.
 
-        This function calculates the energy consumption for each hour from the current hour
-        going back `tgt_duration` hours. It fetches energy data from Home Assistant,
-        processes the data, and sums the energy values. If the total energy for an hour is zero,
-        it skips that hour. The resulting load profile is a list of energy consumption values
-        for each hour.
+    #     This function calculates the energy consumption for each hour from the current hour
+    #     going back `tgt_duration` hours. It fetches energy data from Home Assistant,
+    #     processes the data, and sums the energy values. If the total energy for an hour is zero,
+    #     it skips that hour. The resulting load profile is a list of energy consumption values
+    #     for each hour.
 
-        Args:
-            tgt_duration (int): The target duration in hours for which the load profile is needed.
-            start_time (datetime, optional): The start time for fetching the load profile.
-            Defaults to None.
+    #     Args:
+    #         tgt_duration (int): The target duration in hours for which the load profile is needed.
+    #         start_time (datetime, optional): The start time for fetching the load profile.
+    #         Defaults to None.
 
-        Returns:
-            list: A list of energy consumption values for the specified duration.
-        """
-        logger.info("[LOAD-IF] Creating load profile from Home Assistant ...")
-        current_time = datetime.now(self.time_zone).replace(
-            minute=0, second=0, microsecond=0
-        )
-        if start_time is None:
-            start_time = current_time.replace(
-                hour=0, minute=0, second=0, microsecond=0
-            ) - timedelta(hours=tgt_duration)
-            end_time = start_time + timedelta(hours=tgt_duration)
-        else:
-            start_time = current_time - timedelta(hours=tgt_duration)
-            end_time = current_time
+    #     Returns:
+    #         list: A list of energy consumption values for the specified duration.
+    #     """
+    #     logger.info("[LOAD-IF] Creating load profile from Home Assistant ...")
+    #     current_time = datetime.now(self.time_zone).replace(
+    #         minute=0, second=0, microsecond=0
+    #     )
+    #     if start_time is None:
+    #         start_time = current_time.replace(
+    #             hour=0, minute=0, second=0, microsecond=0
+    #         ) - timedelta(hours=tgt_duration)
+    #         end_time = start_time + timedelta(hours=tgt_duration)
+    #     else:
+    #         start_time = current_time - timedelta(hours=tgt_duration)
+    #         end_time = current_time
 
-        load_profile = []
-        current_hour = start_time
+    #     load_profile = []
+    #     current_hour = start_time
 
-        # current_hour = datetime.strptime("18.03.2025 11:00", "%d.%m.%Y %H:%M")
-        # end_time = current_hour + timedelta(hours=tgt_duration)
+    #     # current_hour = datetime.strptime("18.03.2025 11:00", "%d.%m.%Y %H:%M")
+    #     # end_time = current_hour + timedelta(hours=tgt_duration)
 
-        # check car load data for W or kW
-        car_load_data = self.fetch_historical_energy_data_from_homeassistant(
-            self.car_charge_load_sensor, current_hour, end_time
-        )
-        # check for max value in car_load_data
-        max_car_load = 0
-        car_load_unit_factor = 1
-        for data_entry in car_load_data:
-            try:
-                float(data_entry["state"])
-            except ValueError:
-                continue
-            max_car_load = max(max_car_load, float(data_entry["state"]))
-        if 0 < max_car_load < 23:
-            max_car_load = max_car_load * 1000
-            car_load_unit_factor = 1000
-        logger.debug("[LOAD-IF] Max car load: %s W", round(max_car_load, 0))
+    #     # check car load data for W or kW
+    #     car_load_data = self.__fetch_historical_energy_data_from_homeassistant(
+    #         self.car_charge_load_sensor, current_hour, end_time
+    #     )
+    #     # check for max value in car_load_data
+    #     max_car_load = 0
+    #     car_load_unit_factor = 1
+    #     for data_entry in car_load_data:
+    #         try:
+    #             float(data_entry["state"])
+    #         except ValueError:
+    #             continue
+    #         max_car_load = max(max_car_load, float(data_entry["state"]))
+    #     if 0 < max_car_load < 23:
+    #         max_car_load = max_car_load * 1000
+    #         car_load_unit_factor = 1000
+    #     logger.debug("[LOAD-IF] Max car load: %s W", round(max_car_load, 0))
 
-        while current_hour < end_time:
-            next_hour = current_hour + timedelta(hours=1)
-            # logger.debug("[LOAD-IF] Fetching data for %s to %s", current_hour, next_hour)
-            energy_data = self.fetch_historical_energy_data_from_homeassistant(
-                self.load_sensor, current_hour, next_hour
-            )
-            car_load_data = self.fetch_historical_energy_data_from_homeassistant(
-                self.car_charge_load_sensor, current_hour, next_hour
-            )
+    #     while current_hour < end_time:
+    #         next_hour = current_hour + timedelta(hours=1)
+    #         # logger.debug("[LOAD-IF] Fetching data for %s to %s", current_hour, next_hour)
+    #         energy_data = self.__fetch_historical_energy_data_from_homeassistant(
+    #             self.load_sensor, current_hour, next_hour
+    #         )
+    #         car_load_data = self.__fetch_historical_energy_data_from_homeassistant(
+    #             self.car_charge_load_sensor, current_hour, next_hour
+    #         )
 
-            # print(f'HA Energy data: {car_load_data}')
-            energy = abs(self.process_energy_data({"data": energy_data}))
-            car_load_energy = abs(
-                self.process_energy_data({"data": car_load_data}) * car_load_unit_factor
-            )
-            car_load_energy = max(car_load_energy, 0)  # prevent negative values
-            # print(f'HA Energy Orig: {energy}')
-            # print(f'HA Car load energy: {car_load_energy}')
-            energy = energy - car_load_energy
-            if energy < 0:
-                logger.error(
-                    "[LOAD-IF] DATA ERROR Energy for %s: %5.1f Wh (car load: %5.1f Wh)",
-                    current_hour,
-                    round(energy, 1),
-                    round(car_load_energy, 1),
-                )
-            # print(f'HA Energy Final: {energy}')
-            if energy == 0:
-                current_hour += timedelta(hours=1)
-                continue
+    #         # print(f'HA Energy data: {car_load_data}')
+    #         energy = abs(self.__process_energy_data({"data": energy_data}))
+    #         car_load_energy = abs(
+    #             self.__process_energy_data({"data": car_load_data}) * car_load_unit_factor
+    #         )
+    #         car_load_energy = max(car_load_energy, 0)  # prevent negative values
+    #         # print(f'HA Energy Orig: {energy}')
+    #         # print(f'HA Car load energy: {car_load_energy}')
+    #         energy = energy - car_load_energy
+    #         if energy < 0:
+    #             logger.error(
+    #                 "[LOAD-IF] DATA ERROR Energy for %s: %5.1f Wh (car load: %5.1f Wh)",
+    #                 current_hour,
+    #                 round(energy, 1),
+    #                 round(car_load_energy, 1),
+    #             )
+    #         # print(f'HA Energy Final: {energy}')
+    #         if energy == 0:
+    #             logger.warning(
+    #                 "[LOAD-IF] load = 0 ... Energy for %s: %5.1f Wh (car load: %5.1f Wh)",
+    #                 current_hour,
+    #                 round(energy, 1),
+    #                 round(car_load_energy, 1),
+    #             )
+    #             # current_hour += timedelta(hours=1)
+    #             # continue
 
-            energy_sum = energy
+    #         energy_sum = energy
 
-            load_profile.append(energy_sum)
-            logger.debug(
-                "[LOAD-IF] Energy for %s: %5.1f Wh (car load: %5.1f Wh)",
-                current_hour,
-                round(energy, 1),
-                round(car_load_energy, 1),
-            )
-            # logger.debug("[LOAD-IF] Energy for %s: %s", current_hour, round(energy_sum,1))
+    #         load_profile.append(energy_sum)
+    #         logger.debug(
+    #             "[LOAD-IF] Energy for %s: %5.1f Wh (car load: %5.1f Wh)",
+    #             current_hour,
+    #             round(energy, 1),
+    #             round(car_load_energy, 1),
+    #         )
+    #         # logger.debug("[LOAD-IF] Energy for %s: %s", current_hour, round(energy_sum,1))
 
-            current_hour += timedelta(hours=1)
-        logger.info("[LOAD-IF] Load profile created successfully.")
-        return load_profile
+    #         current_hour += timedelta(hours=1)
+    #     logger.info("[LOAD-IF] Load profile created successfully.")
+    #     return load_profile
 
     def __get_car_load_list_from_to(self, start_time, end_time):
         """
@@ -331,23 +359,21 @@ class LoadInterface:
             - All load values are multiplied by the determined unit factor before being returned.
         """
 
-        # check car load data for W or kW
-        car_load_data = self.fetch_historical_energy_data_from_homeassistant(
-            self.car_charge_load_sensor, start_time, end_time
-        )
-        # check for max value in car_load_data
-        # max_car_load = 0
-        # car_load_unit_factor = 1
-        # for data_entry in car_load_data:
-        #     try:
-        #         float(data_entry["state"])
-        #     except ValueError:
-        #         continue
-        #     max_car_load = max(max_car_load, float(data_entry["state"]))
-        # if 0 < max_car_load < 23:
-        #     max_car_load = max_car_load * 1000
-        #     car_load_unit_factor = 1000
-        # logger.debug("[LOAD-IF] Max car load: %s W", round(max_car_load,0))
+        if self.src == "openhab":
+            car_load_data = self.__fetch_historical_energy_data_from_openhab(
+                self.car_charge_load_sensor, start_time, end_time
+            )
+        elif self.src == "homeassistant":
+            car_load_data = self.__fetch_historical_energy_data_from_homeassistant(
+                self.car_charge_load_sensor, start_time, end_time
+            )
+        else:
+            logger.error(
+                "[LOAD-IF] Car Load source '%s' currently not supported. Using default.",
+                self.src,
+            )
+            return []
+
         # multiply every value with car_load_unit_factor before returning
         for data_entry in car_load_data:
             try:
@@ -382,28 +408,44 @@ class LoadInterface:
         while current_hour < end_time:
             next_hour = current_hour + timedelta(hours=1)
             # logger.debug("[LOAD-IF] Fetching data for %s to %s", current_hour, next_hour)
-            energy_data = self.fetch_historical_energy_data_from_homeassistant(
-                self.load_sensor, current_hour, next_hour
-            )
-            car_load_data = self.__get_car_load_list_from_to(current_hour, next_hour)
+            if self.src == "openhab":
+                energy_data = self.__fetch_historical_energy_data_from_openhab(
+                    self.load_sensor, current_hour, next_hour
+                )
+            elif self.src == "homeassistant":
+                energy_data = self.__fetch_historical_energy_data_from_homeassistant(
+                    self.load_sensor, current_hour, next_hour
+                )
+            else:
+                logger.error(
+                    "[LOAD-IF] Load source '%s' currently not supported. Using default.",
+                    self.src,
+                )
+                return []
 
-            energy = abs(self.process_energy_data({"data": energy_data}))
-            car_load_energy = abs(self.process_energy_data({"data": car_load_data}))
-            # print(f'HA Car load data: {car_load_data} --- {energy}')
+            car_load_data = self.__get_car_load_list_from_to(current_hour, next_hour)
+            energy = abs(self.__process_energy_data({"data": energy_data}))
+            car_load_energy = abs(self.__process_energy_data({"data": car_load_data}))
             car_load_energy = max(car_load_energy, 0)  # prevent negative values
             if car_load_energy <= energy:
                 energy = energy - car_load_energy
             else:
                 logger.error(
-                    "[LOAD-IF] DATA ERROR load smaller than car load "+
-                    "- Energy for %s: %5.1f Wh (car load: %5.1f Wh)",
+                    "[LOAD-IF] DATA ERROR load smaller than car load "
+                    + "- Energy for %s: %5.1f Wh (car load: %5.1f Wh)",
                     current_hour,
                     round(energy, 1),
                     round(car_load_energy, 1),
                 )
             if energy == 0:
-                current_hour += timedelta(hours=1)
-                continue
+                logger.warning(
+                    "[LOAD-IF] load = 0 ... Energy for %s: %5.1f Wh (car load: %5.1f Wh)",
+                    current_hour,
+                    round(energy, 1),
+                    round(car_load_energy, 1),
+                )
+                # current_hour += timedelta(hours=1)
+                # continue
 
             energy_sum = energy
 
@@ -423,7 +465,7 @@ class LoadInterface:
             )
         return load_profile
 
-    def create_load_profile_homeassistant_weekdays(self):
+    def __create_load_profile_weekdays(self):
         """
         Creates a load profile for weekdays based on historical data from Home Assistant.
         This method calculates the average load profile for the same day of the week
@@ -565,15 +607,9 @@ class LoadInterface:
                 200.0,  # 23:00 - 0:00
             ]
             return default_profile[:tgt_duration]
-        if self.src == "openhab":
-            # logger.info("[LOAD-IF] Using load source openhab")
-            return self.create_load_profile_openhab_from_last_days(
-                tgt_duration, start_time
-            )
-        if self.src == "homeassistant":
-            # logger.info("[LOAD-IF] Using load source homeassistant")
-            # return self.create_load_profile_homeassistant_from_last_days(tgt_duration, start_time)
-            return self.create_load_profile_homeassistant_weekdays()
+        if self.src == "openhab" or self.src == "homeassistant":
+            return self.__create_load_profile_weekdays()
+
         logger.error(
             "[LOAD-IF] Load source '%s' currently not supported. Using default.",
             self.src,

--- a/src/interfaces/mqtt_interface.py
+++ b/src/interfaces/mqtt_interface.py
@@ -677,7 +677,7 @@ class MqttInterface:
             }
             payload["device"] = device
             logger.debug(
-                "Sending HA AD config message for %s",
+                "[MQTT] Sending HA AD config message for %s",
                 self.auto_discover_topic
                 + "/"
                 + item_type


### PR DESCRIPTION
- closes #38 openHAB: Extension of the load data range to a configurable value between 2 days and 2 weeks
- refactoring of load interface to have same result for openhab and homeassistant source