### PR TITLE
feat: used information about planed car charging to build load profile

### DIFF
--- a/src/eos_connect.py
+++ b/src/eos_connect.py
@@ -237,6 +237,7 @@ evcc_interface = EvccInterface(
 load_interface = LoadInterface(
     config_manager.config.get("load", {}),
     time_zone,
+    evcc_interface,
 )
 
 battery_interface = BatteryInterface(

--- a/src/interfaces/evcc_interface.py
+++ b/src/interfaces/evcc_interface.py
@@ -87,23 +87,6 @@ class EvccInterface:
         self.last_known_charging_state = False
         # off, pv, pvmin, now
         self.last_known_charging_mode = None
-        self.current_detail_data_list = [
-            {
-                "connected": False,
-                "charging": False,
-                "mode": "off",
-                "chargeDuration": 0,
-                "chargeRemainingDuration": 0,
-                "chargedEnergy": 0,
-                "chargeRemainingEnergy": 0,
-                "sessionEnergy": 0,
-                "vehicleSoc": 0,
-                "vehicleRange": 0,
-                "vehicleOdometer": 0,
-                "vehicleName": "",
-                "smartCostActive": False,
-            }
-        ]
         self.external_battery_mode_en = ext_bat_mode
         self.external_battery_mode = "off"  # Default mode
 
@@ -212,6 +195,8 @@ class EvccInterface:
                 "vehicleOdometer": 0,
                 "vehicleName": "",
                 "smartCostActive": False,
+                "planProjectedStart": "",
+                "planProjectedEnd": "",
             }
         ]
 
@@ -418,6 +403,8 @@ class EvccInterface:
                 "vehicleOdometer": loadpoint.get("vehicleOdometer", 0),
                 "vehicleName": vehicle_name,
                 "smartCostActive": loadpoint.get("smartCostActive", False),
+                "planProjectedStart": loadpoint.get("planProjectedStart", ""),
+                "planProjectedEnd": loadpoint.get("planProjectedEnd", ""),
             }
             self.current_detail_data_list.append(detail_data)
         return True


### PR DESCRIPTION
with this any planned charging is added to the profile. The information that charging will happen exist so we can use it to build a more precise prediction. For simplicity the amount needed energy is evenly distributed over the charging hours. This is wrong if for example the late-charge option is set so that there is a pause between start and finish of the charging session.

Let me know what you thing about this in general and if I should implement sth. in a different way