### PR TITLE
Cache for Tibber API responses

### DIFF
--- a/src/interfaces/price_interface.py
+++ b/src/interfaces/price_interface.py
@@ -21,7 +21,7 @@ Usage:
         "feed_in_tariff_price": 5.0,
         "negative_price_switch": True,
         "fixed_24h_array": [10.0] * 24,
-        "use_cache": True,
+        "use_cache": False,
         "cache_expiry_minutes": 60
     }
     price_interface = PriceInterface(config, timezone="Europe/Berlin")
@@ -104,7 +104,7 @@ class PriceInterface:
             self.fixed_24h_array = False
         self.feed_in_tariff_price = config.get("feed_in_price", 0.0)
         self.negative_price_switch = config.get("negative_price_switch", False)
-        self.use_cache = config.get("use_cache", True)
+        self.use_cache = config.get("use_cache", False)
         self.cache_expiry_minutes = config.get("cache_expiry_minutes", 60)
         self.time_zone = timezone
         self.current_prices = []


### PR DESCRIPTION
This adds a simple caching mechanism for the Tibber price API.

I've seen a couple API timeouts happening and with the old behavior it falls back to default pricing, causing the predictions to be very off (given it's 10ct every hour flat). This caused some flapping in my control logic.

Given Tibber prices are pretty stable between API calls, i thought it might be better to first fall back to the last successful tibber price data received. This change introduces 2 new config flags on pricing: `use_cache` (default: `False`) and `cache_expiry_minutes` (default: 60 minutes). This should allow a brief intermittent API failure without throwing of the whole prediction.