### PR TITLE
[FIX] catch more exceptions in main loop

### DIFF
--- a/src/eos_connect.py
+++ b/src/eos_connect.py
@@ -806,7 +806,7 @@ class OptimizationScheduler:
                     seconds,
                 )
 
-            except (requests.exceptions.RequestException, ValueError, KeyError) as e:
+            except (requests.exceptions.RequestException, ValueError, KeyError, TypeError) as e:
                 logger.error("[OPTIMIZATION] Error while updating state: %s", e)
                 actual_sleep_interval = self.update_interval  # Fallback on error
 


### PR DESCRIPTION
I noticed that an exception was not catched in the main loop:

```
eos_connect-1  | 2025-11-06 04:41:16 ERROR [PV-IF] EVCC API error: 'list' object has no attribute 'json'
eos_connect-1  | 2025-11-06 04:41:16 ERROR [PV-IF] No valid solar forecast data found in EVCC API.
eos_connect-1  | 2025-11-06 04:41:16 WARNING [PV-IF] Using default PV forecast due to previous error: No valid solar forecast data found in EVCC API.
eos_connect-1  | 2025-11-06 04:41:17 INFO [Main] Initializing EOS Connect web server...
eos_connect-1  | 2025-11-06 04:41:17 INFO [PortInterface] Creating web server on 0.0.0.0:8081
eos_connect-1  | 2025-11-06 04:41:17 INFO [Main] EOS Connect web server successfully created on 0.0.0.0:8081
eos_connect-1  | 2025-11-06 04:41:17 INFO [Main] Web interface available at: http://localhost:8081
eos_connect-1  | 2025-11-06 04:41:17 INFO [Main] Starting EOS Connect web server...
eos_connect-1  | 2025-11-06 04:41:17 INFO [PV-IF] PV and Temperature updated
eos_connect-1  | 2025-11-06 04:41:58 INFO [EOS] OPTIMIZE request optimization with: http://eos:8503/optimize?start_hour=4 - and with timeout: 300
eos_connect-1  | Exception in thread Thread-6 (__update_state_optimization_loop):
eos_connect-1  | 2025-11-06 04:41:58 INFO [EOS] OPTIMIZE response retrieved successfully in 0 min 0.01 sec for current run
eos_connect-1  | 2025-11-06 04:41:58 ERROR [EOS] OPTIMIZE Request failed: 422 Client Error: Unprocessable Entity for url: http://eos:8503/optimize?start_hour=4
eos_connect-1  | 2025-11-06 04:41:58 ERROR [EOS] OPTIMIZE Response status: 422
eos_connect-1  | 2025-11-06 04:41:58 ERROR [OPT] No control data in optimized response
eos_connect-1  | Traceback (most recent call last):
eos_connect-1  |   File "/usr/local/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
eos_connect-1  |     self.run()
eos_connect-1  |     ~~~~~~~~^^
eos_connect-1  |   File "/usr/local/lib/python3.13/threading.py", line 994, in run
eos_connect-1  |     self._target(*self._args, **self._kwargs)
eos_connect-1  |     ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
eos_connect-1  |   File "/app/eos_connect.py", line 765, in __update_state_optimization_loop
eos_connect-1  |     next_eval = eos_interface.calculate_next_run_time(
eos_connect-1  |         loop_now,
eos_connect-1  |         getattr(self, "_last_avg_runtime", 120),  # Use last known runtime
eos_connect-1  |         self.update_interval,
eos_connect-1  |     )
eos_connect-1  |   File "/app/interfaces/optimization_interface.py", line 227, in calculate_next_run_time
eos_connect-1  |     min_gap_seconds = max((update_interval + avg_runtime) * 0.7, 30)
eos_connect-1  |                            ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
eos_connect-1  | TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
eos_connect-1  | 2025-11-06 04:41:59 INFO [Main] Inverter mode set to MODE AVOID DISCHARGE (_____-----_____)
```

Not sure what caused the original issue, but in any case, the main loop should handle the exception. Otherwise, the thread will exit and EOS_connect will be in a zombie-like state.