### PR TITLE
fix: implement missing "timeseries" PV forecast source dispatch

### DIFF
--- a/src/interfaces/pv_interface.py
+++ b/src/interfaces/pv_interface.py
@@ -950,6 +950,10 @@ class PvInterface:
             logger.debug("[PV-IF] fetching forecast for evcc config")
             forecast = self.__get_pv_forecast("evcc_config")
             forecast_values = forecast
+        elif self.config_source.get("source") == "timeseries":
+            logger.debug("[PV-IF] fetching forecast for timeseries config")
+            forecast = self.__get_pv_forecast_timeseries()
+            forecast_values = forecast
         else:
             for config_entry in self.config:
                 logger.debug("[PV-IF] fetching forecast for '%s'", config_entry["name"])
@@ -974,6 +978,315 @@ class PvInterface:
             )
 
         return forecast_values
+
+    def __get_pv_forecast_timeseries(self, tgt_duration=48):
+        """
+        Retrieve the PV forecast from a generic timeseries data source (HTTP
+        endpoint or Home Assistant sensor), analogous to
+        PriceInterface.__retrieve_prices_from_url.
+
+        Fetched once globally (not per pv_forecast.N array entry), since the
+        external source is expected to already provide the combined forecast
+        for the whole installation - mirrors how the "evcc" source is handled.
+
+        Standardized format: [{start, end, value}, ...] with value in Wh for
+        that slot (hourly or 15-min resolution, auto-detected).
+
+        Config fields used (from pv_forecast_source):
+        - data_url: Full HTTP endpoint URL (HA or HTTP custom endpoint)
+        - data_path: JSON path to the timeseries array (e.g. "data")
+        - data_token: Optional bearer token for authentication
+        """
+        data_url = self.config_source.get("data_url", "").strip()
+        data_path = self.config_source.get("data_path", "data").strip() or "data"
+        data_token = self.config_source.get("data_token", "").strip()
+
+        fallback_power = self.config[0]["power"] if self.config else 1000
+
+        if not data_url:
+            return self._handle_interface_error(
+                "config_error",
+                "Data URL (data_url) not configured for timeseries PV source",
+                "timeseries_config",
+                "timeseries",
+            ) or self.__get_default_pv_forcast(fallback_power)
+
+        headers = {"Content-Type": "application/json"}
+        if data_token:
+            headers["Authorization"] = f"Bearer {data_token}"
+
+        logger.debug(
+            "[PV-IF] Fetching PV forecast from timeseries source: %s (path: %s)",
+            data_url,
+            data_path,
+        )
+
+        def request_and_parse():
+            response = requests.get(data_url, headers=headers, timeout=10)
+            response.raise_for_status()
+            response_data = response.json()
+            timeseries = self.__extract_json_path(response_data, data_path)
+            if not isinstance(timeseries, list):
+                raise ValueError(f"Data at path '{data_path}' is not a list")
+            return timeseries
+
+        def error_handler(error_type, exception):
+            return self._handle_interface_error(
+                error_type,
+                f"Timeseries data source error: {exception}",
+                "timeseries_source",
+                "timeseries",
+            )
+
+        timeseries = self._retry_request(request_and_parse, error_handler)
+        if not timeseries:
+            return self.last_successful_pv_forecast or self.__get_default_pv_forcast(
+                fallback_power
+            )
+
+        try:
+            forecast_values = self.__parse_pv_timeseries(timeseries, tgt_duration)
+            if not forecast_values:
+                return self._handle_interface_error(
+                    "processing_error",
+                    "Failed to parse PV timeseries data",
+                    "timeseries_source",
+                    "timeseries",
+                ) or self.__get_default_pv_forcast(fallback_power)
+            self.pv_forcast_request_error["error"] = None
+            return forecast_values
+        except (ValueError, TypeError) as e:
+            return self._handle_interface_error(
+                "processing_error",
+                f"Error parsing PV timeseries: {e}",
+                "timeseries_source",
+                "timeseries",
+            ) or self.__get_default_pv_forcast(fallback_power)
+
+    def __parse_pv_timeseries(self, timeseries, tgt_duration, resolution_seconds=None):
+        """
+        Parse and validate a PV forecast timeseries.
+
+        Standardized format: [{start, end, value}, ...]
+        - start/end: ISO8601 string or Unix timestamp (seconds)
+        - value: generated energy in Wh for that slot (non-negative)
+        - Supports hourly (48 values) or 15-minute (192 values) resolution
+
+        Mirrors PriceInterface.__parse_price_timeseries, adapted for PV: values
+        represent energy-per-slot rather than a rate, so 15-min-to-hourly
+        conversion sums instead of averages, and missing trailing slots are
+        padded with 0 (no production) rather than the last known value.
+        """
+        if not timeseries or not isinstance(timeseries, list):
+            logger.error("[PV-IF] PV timeseries is not a list")
+            return []
+
+        if len(timeseries) == 0:
+            logger.error("[PV-IF] PV timeseries is empty")
+            return []
+
+        first = timeseries[0]
+        required_keys = ["start", "end", "value"]
+        if not isinstance(first, dict) or not all(k in first for k in required_keys):
+            logger.error(
+                "[PV-IF] Invalid PV timeseries format: missing start, end, or value"
+            )
+            return []
+
+        if resolution_seconds is None:
+            resolution_seconds = self.__detect_pv_timeseries_resolution(timeseries)
+            if resolution_seconds is None:
+                logger.error("[PV-IF] Could not detect PV timeseries resolution")
+                return []
+
+        if resolution_seconds == 900 and self.time_frame_base == 3600:
+            logger.debug(
+                "[PV-IF] Converting source 15-min to system hourly resolution"
+            )
+            timeseries = self.__convert_15min_to_hourly_pv_timeseries(timeseries)
+        elif resolution_seconds == 3600 and self.time_frame_base == 900:
+            logger.error(
+                "[PV-IF] Resolution mismatch: data source provides hourly (3600s) "
+                "but system configured for 15-min (900s) slots. "
+                "Set time_frame_base to 3600 or switch to a 15-minute data source."
+            )
+            return []
+        elif resolution_seconds not in (900, 3600):
+            logger.error(
+                "[PV-IF] Unsupported resolution: %d seconds (expected 900 or 3600)",
+                resolution_seconds,
+            )
+            return []
+
+        # Align by absolute timestamp to the slot grid starting at local midnight
+        # today - NOT positionally. get_ems_data() indexes pv_forcast_array by
+        # "slots since midnight" (see eos_connect.py's current_slot calculation),
+        # the same convention __get_pv_forecast_evcc_api() already follows. A
+        # source whose first entry is "now" (like ours) rather than "midnight"
+        # would otherwise land at the wrong array index.
+        try:
+            tz = pytz.timezone(self.time_zone)
+        except (pytz.UnknownTimeZoneError, AttributeError):
+            tz = pytz.UTC
+
+        def parse_ts(ts_val):
+            if isinstance(ts_val, (int, float)):
+                return datetime.fromtimestamp(ts_val, tz=pytz.UTC).astimezone(tz)
+            if isinstance(ts_val, str):
+                try:
+                    parsed = datetime.fromisoformat(ts_val.replace("Z", "+00:00"))
+                except ValueError:
+                    parsed = datetime.fromisoformat(ts_val)
+                if parsed.tzinfo is None:
+                    parsed = tz.localize(parsed)
+                return parsed.astimezone(tz)
+            return None
+
+        slot_seconds = 3600 if self.time_frame_base == 3600 else 900
+        lookup = {}
+        try:
+            for item in timeseries:
+                ts = parse_ts(item.get("start"))
+                if ts is None:
+                    continue
+                value = float(item.get("value", 0))
+                if value < 0:
+                    logger.warning("[PV-IF] Negative PV value %.1f clamped to 0", value)
+                    value = 0.0
+                ts = ts.replace(second=0, microsecond=0)
+                lookup[ts] = value
+        except (ValueError, TypeError):
+            logger.error("[PV-IF] Failed to extract numeric PV values")
+            return []
+
+        now_local = datetime.now(tz)
+        midnight_today = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        expected_count = 48 if self.time_frame_base == 3600 else 192
+        values = [
+            round(lookup.get(midnight_today + timedelta(seconds=slot_seconds * i), 0.0), 1)
+            for i in range(expected_count)
+        ]
+
+        return values
+
+    def __detect_pv_timeseries_resolution(self, timeseries):
+        """
+        Detect time resolution (900s for 15-min, 3600s for hourly).
+        Identical logic to PriceInterface.__detect_price_timeseries_resolution.
+
+        Returns:
+            int: Seconds per interval (900 or 3600), or None if cannot detect
+        """
+        if len(timeseries) < 2:
+            return None
+
+        try:
+            from datetime import datetime as dt_class
+            import pytz
+
+            def parse_ts(ts_str):
+                if isinstance(ts_str, (int, float)):
+                    return dt_class.fromtimestamp(ts_str, tz=pytz.UTC)
+                if isinstance(ts_str, str):
+                    try:
+                        return dt_class.fromisoformat(ts_str.replace("Z", "+00:00"))
+                    except ValueError:
+                        return dt_class.fromisoformat(ts_str)
+                return None
+
+            start1 = parse_ts(timeseries[0].get("start"))
+            start2 = parse_ts(timeseries[1].get("start"))
+
+            if start1 is None or start2 is None:
+                return None
+
+            delta = int((start2 - start1).total_seconds())
+
+            if delta == 900:
+                logger.debug("[PV-IF] Detected 15-minute PV timeseries resolution")
+                return 900
+            elif delta == 3600:
+                logger.debug("[PV-IF] Detected hourly PV timeseries resolution")
+                return 3600
+            else:
+                logger.warning(
+                    "[PV-IF] Unexpected PV timeseries resolution delta: %d seconds",
+                    delta,
+                )
+                return None
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def __convert_15min_to_hourly_pv_timeseries(self, timeseries):
+        """
+        Convert 15-minute PV energy values to hourly by summing 4 consecutive
+        slots. Unlike PriceInterface's rate-based averaging, PV values are
+        energy-per-slot, so summing (not averaging) is the correct aggregation.
+
+        Returns:
+            list: Hourly timeseries with summed values
+        """
+        if len(timeseries) < 4:
+            logger.warning("[PV-IF] Not enough 15-min PV data to sum hourly")
+            return timeseries
+
+        hourly = []
+        for i in range(0, len(timeseries), 4):
+            group = timeseries[i : i + 4]
+            try:
+                total_value = sum(float(item.get("value", 0)) for item in group)
+                hourly.append(
+                    {
+                        "start": group[0].get("start"),
+                        "end": group[-1].get("end"),
+                        "value": total_value,
+                    }
+                )
+            except (ValueError, TypeError):
+                pass
+
+        logger.debug(
+            "[PV-IF] Converted %d 15-min PV values to %d hourly values",
+            len(timeseries),
+            len(hourly),
+        )
+        return hourly
+
+    def __extract_json_path(self, obj, path):
+        """
+        Extract nested value from JSON object using dot notation.
+
+        Examples:
+        - 'attributes.data' -> obj['attributes']['data']
+        - 'data' -> obj['data']
+        - 'prices[0].data' -> obj['prices'][0]['data']
+
+        Args:
+            obj: JSON object (dict or list)
+            path: Dot-notation path string
+
+        Returns:
+            Extracted value or None if path not found
+        """
+        try:
+            parts = path.split(".")
+            current = obj
+            for part in parts:
+                if "[" in part:
+                    key, index_str = part.split("[")
+                    index = int(index_str.rstrip("]"))
+                    if key:
+                        current = current[key][index]
+                    else:
+                        current = current[index]
+                else:
+                    current = current[part]
+            return current
+        except (KeyError, IndexError, TypeError, ValueError):
+            logger.warning(
+                "[PV-IF] Could not extract path '%s' from JSON response", path
+            )
+            return None
 
     def __get_pv_forecast_akkudoktor_api(
         self, tgt_value="power", pv_config_entry=None, tgt_duration=48

--- a/tests/interfaces/test_pv_timeseries_parsing.py
+++ b/tests/interfaces/test_pv_timeseries_parsing.py
@@ -1,0 +1,254 @@
+# pylint: disable=protected-access
+"""
+Tests for the PV "timeseries" data source: fetch, resolution detection,
+15-min-to-hourly conversion, and parsing/validation.
+
+Mirrors tests/interfaces/test_timeseries_parsing.py (PriceInterface), adapted
+for PV semantics: values are energy-per-slot (Wh), 15-min slots are summed
+(not averaged) when converted to hourly, incomplete data is padded with 0 (no
+production) instead of the last known value, and - critically, matching
+__get_pv_forecast_evcc_api's existing behaviour - entries are aligned to the
+array by absolute timestamp starting at local midnight today (not
+positionally / not starting from "now"), since get_ems_data() in
+eos_connect.py indexes pv_forcast_array by slots-since-midnight.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+import pytz
+import pytest
+
+from src.interfaces.pv_interface import PvInterface
+
+TIME_FRAME_BASE_HOURLY = 3600
+TIME_FRAME_BASE_15MIN = 900
+
+
+@pytest.fixture(autouse=True)
+def patch_thread(monkeypatch):
+    """Avoid starting the real background update thread during tests."""
+
+    class DummyThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr("threading.Thread", DummyThread)
+
+
+def midnight_today_utc():
+    return datetime.now(pytz.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def make_pv_interface(source_config=None, config=None, time_frame_base=TIME_FRAME_BASE_HOURLY):
+    source_config = source_config or {"source": "timeseries"}
+    config = config if config is not None else [{"name": "test_array", "power": 4000}]
+    return PvInterface(source_config, config, time_frame_base, {}, timezone="UTC")
+
+
+class TestPvTimeseriesFormatValidation:
+    """Strict format validation for incoming PV timeseries data."""
+
+    def test_valid_hourly_format(self):
+        pv = make_pv_interface()
+        base = midnight_today_utc()
+        timeseries = [
+            {"start": (base + timedelta(hours=h)).isoformat(), "end": (base + timedelta(hours=h + 1)).isoformat(), "value": 100.0}
+            for h in range(48)
+        ]
+
+        values = pv._PvInterface__parse_pv_timeseries(timeseries, 48)
+        assert values is not None
+        assert len(values) == 48
+        assert all(isinstance(v, float) for v in values)
+        assert all(v == 100.0 for v in values)
+
+    def test_missing_start_field(self):
+        pv = make_pv_interface()
+        timeseries = [{"end": "2024-01-01T01:00:00Z", "value": 100.0}]
+        assert pv._PvInterface__parse_pv_timeseries(timeseries, 48) == []
+
+    def test_missing_value_field(self):
+        pv = make_pv_interface()
+        timeseries = [{"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T01:00:00Z"}]
+        assert pv._PvInterface__parse_pv_timeseries(timeseries, 48) == []
+
+    def test_not_a_list(self):
+        pv = make_pv_interface()
+        assert pv._PvInterface__parse_pv_timeseries({"data": "not a list"}, 48) == []
+
+    def test_empty_list(self):
+        pv = make_pv_interface()
+        assert pv._PvInterface__parse_pv_timeseries([], 48) == []
+
+    def test_negative_value_clamped_to_zero(self):
+        pv = make_pv_interface()
+        base = midnight_today_utc()
+        timeseries = [
+            {"start": (base + timedelta(hours=h)).isoformat(), "end": (base + timedelta(hours=h + 1)).isoformat(), "value": -50.0}
+            for h in range(48)
+        ]
+        values = pv._PvInterface__parse_pv_timeseries(timeseries, 48)
+        assert all(v == 0.0 for v in values)
+
+
+class TestPvResolutionDetection:
+    def test_detect_hourly_resolution(self):
+        pv = make_pv_interface()
+        timeseries = [
+            {"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T01:00:00Z", "value": 100.0},
+            {"start": "2024-01-01T01:00:00Z", "end": "2024-01-01T02:00:00Z", "value": 200.0},
+        ]
+        assert pv._PvInterface__detect_pv_timeseries_resolution(timeseries) == 3600
+
+    def test_detect_15min_resolution(self):
+        pv = make_pv_interface()
+        timeseries = [
+            {"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T00:15:00Z", "value": 100.0},
+            {"start": "2024-01-01T00:15:00Z", "end": "2024-01-01T00:30:00Z", "value": 100.0},
+        ]
+        assert pv._PvInterface__detect_pv_timeseries_resolution(timeseries) == 900
+
+    def test_hourly_source_to_15min_system_rejected(self):
+        pv = make_pv_interface(time_frame_base=TIME_FRAME_BASE_15MIN)
+        timeseries = [
+            {"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T01:00:00Z", "value": 100.0},
+            {"start": "2024-01-01T01:00:00Z", "end": "2024-01-01T02:00:00Z", "value": 200.0},
+        ] * 24
+        assert pv._PvInterface__parse_pv_timeseries(timeseries, 192) == []
+
+
+class TestPvAveraging:
+    """15-min PV values are summed into hourly totals, not averaged (energy, not a rate)."""
+
+    def test_sum_4_values_to_1(self):
+        pv = make_pv_interface()
+        timeseries = [
+            {"start": "2024-01-01T00:00:00Z", "end": "2024-01-01T00:15:00Z", "value": 100.0},
+            {"start": "2024-01-01T00:15:00Z", "end": "2024-01-01T00:30:00Z", "value": 150.0},
+            {"start": "2024-01-01T00:30:00Z", "end": "2024-01-01T00:45:00Z", "value": 200.0},
+            {"start": "2024-01-01T00:45:00Z", "end": "2024-01-01T01:00:00Z", "value": 250.0},
+        ]
+        hourly = pv._PvInterface__convert_15min_to_hourly_pv_timeseries(timeseries)
+        assert len(hourly) == 1
+        # Sum: 100 + 150 + 200 + 250 = 700 (not the 175 average)
+        assert hourly[0]["value"] == 700.0
+
+    def test_15min_source_to_hourly_system_end_to_end(self):
+        pv = make_pv_interface()
+        base = midnight_today_utc()
+        timeseries = []
+        for h in range(48):
+            hour_start = base + timedelta(hours=h)
+            for q in range(4):
+                timeseries.append(
+                    {
+                        "start": (hour_start + timedelta(minutes=15 * q)).isoformat(),
+                        "end": (hour_start + timedelta(minutes=15 * (q + 1))).isoformat(),
+                        "value": 100.0,
+                    }
+                )
+        values = pv._PvInterface__parse_pv_timeseries(timeseries, 48)
+        assert len(values) == 48
+        assert values[0] == 400.0  # 4 x 100 Wh summed
+
+
+class TestPvDataCompleteness:
+    def test_incomplete_hourly_data_padded_with_zero(self):
+        pv = make_pv_interface()
+        base = midnight_today_utc()
+        timeseries = [
+            {"start": (base + timedelta(hours=h)).isoformat(), "end": (base + timedelta(hours=h + 1)).isoformat(), "value": 500.0}
+            for h in range(24)  # only today's 24 hours, tomorrow left empty
+        ]
+        values = pv._PvInterface__parse_pv_timeseries(timeseries, 48)
+        assert len(values) == 48
+        assert values[:24] == [500.0] * 24
+        # PV pads missing slots (no data returned for them) with 0, not the last known value
+        assert values[24:] == [0.0] * 24
+
+
+class TestPvTimeseriesFetchDispatch:
+    """get_summarized_pv_forecast() should route to the timeseries fetcher and
+    bypass the per-pv_forecast-entry loop, mirroring the existing evcc special case."""
+
+    def test_dispatches_to_timeseries_and_skips_per_entry_loop(self):
+        source_config = {
+            "source": "timeseries",
+            "data_url": "http://test.local/timeseries",
+            "data_path": "data",
+        }
+        # Two pv_forecast entries configured, like Nord/Ost/West - if the dispatcher
+        # fell through to the per-entry loop, the (wrong) default forecast would be
+        # requested and summed twice.
+        config = [
+            {"name": "Nord", "power": 4800},
+            {"name": "Ost", "power": 2000},
+        ]
+        pv = make_pv_interface(source_config=source_config, config=config)
+        pv.configuration_valid = True
+
+        base = midnight_today_utc()
+        api_timeseries = [
+            {"start": (base + timedelta(hours=h)).isoformat(), "end": (base + timedelta(hours=h + 1)).isoformat(), "value": 42.0}
+            for h in range(48)
+        ]
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"data": api_timeseries}
+
+        with patch("requests.get", return_value=mock_response) as mock_get:
+            result = pv.get_summarized_pv_forecast()
+
+        mock_get.assert_called_once()
+        assert result[0] == 42.0
+        assert len(result) == 48
+        # Not 84.0 (which double-counting via the per-entry loop would produce)
+
+    def test_missing_data_url_falls_back_to_default(self):
+        source_config = {"source": "timeseries"}  # no data_url
+        pv = make_pv_interface(source_config=source_config, config=[{"name": "test", "power": 1000}])
+        pv.configuration_valid = True
+
+        result = pv.get_summarized_pv_forecast()
+        # __get_default_pv_forcast repeats its 24h triangle pattern for 48h total
+        assert len(result) == 48
+        assert max(result) == 700.0  # 1000 W * 0.7 peak factor
+        assert result[0] == 0.0  # 00:00 is always 0 in the default shape
+
+    def test_values_align_to_midnight_not_to_now(self):
+        """The critical regression test: a source whose first entry is "now" (not
+        midnight) - exactly what our own pv-forecast-corrector service returns -
+        must still land at the correct slots-since-midnight index, not at index 0."""
+        source_config = {
+            "source": "timeseries",
+            "data_url": "http://test.local/timeseries",
+            "data_path": "data",
+        }
+        pv = make_pv_interface(source_config=source_config, config=[{"name": "test", "power": 1000}])
+        pv.configuration_valid = True
+
+        now = datetime.now(pytz.UTC).replace(minute=0, second=0, microsecond=0)
+        base = midnight_today_utc()
+        hours_since_midnight = int((now - base).total_seconds() // 3600)
+
+        # Source has two real data points starting at "now" (needs >= 2 entries for
+        # resolution detection); everything else in its own 48h window would also
+        # be present in a real feed, but for this regression check that's enough.
+        api_timeseries = [
+            {"start": now.isoformat(), "end": (now + timedelta(hours=1)).isoformat(), "value": 777.0},
+            {"start": (now + timedelta(hours=1)).isoformat(), "end": (now + timedelta(hours=2)).isoformat(), "value": 888.0},
+        ]
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"data": api_timeseries}
+
+        with patch("requests.get", return_value=mock_response):
+            result = pv.get_summarized_pv_forecast()
+
+        assert result[hours_since_midnight] == 777.0
+        if hours_since_midnight > 0:
+            assert result[0] == 0.0  # midnight slot itself has no data in this feed


### PR DESCRIPTION
pv_forecast_source.source: timeseries was accepted by config validation and configurable in the UI (data_url, data_path, data_token), but PvInterface.__get_pv_forecast() had no case for it, silently falling back to the synthetic default triangle forecast instead of fetching data_url.

Adds __get_pv_forecast_timeseries(), reusing the same standardized [{start, end, value}] format PriceInterface's timeseries source already uses, with a PV-appropriate twist: 15-min-to-hourly conversion sums (not averages, since values are energy-per-slot rather than a rate), and incomplete data pads with 0 instead of the last known value.

Fetched once globally (not per pv_forecast.N array entry) and aligned by absolute "start" timestamp to a midnight-anchored slot grid - both match __get_pv_forecast_evcc_api's existing behaviour, and are required because get_ems_data() in eos_connect.py indexes pv_forcast_array by slots-since-midnight-today, not by position.

Tested against a self-hosted forecast service returning real 15-minute-resolution PV data; verified end to end against the running optimizer (matching totals between the service and EOS_connect's own computed values).

Fixes #270