### PR TITLE
fix: probe CBC before use, prefer runnable binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test_config_ui.py
 *.db
 *.db-wal
 *.db-shm
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -95,12 +95,9 @@ Supported data sources and integrations:
 
 ⚠️ **Important: Proxmox / KVM64 CPU Limitation**
 
-If you experience issues with EOS Connect on **Proxmox** with the default CPU type, your VM is likely using `kvm64` (a generic CPU emulation). This can cause two types of failures:
+If EOS Connect **crashes with a segmentation fault on startup** on **Proxmox** with the default CPU type, your VM is likely using `kvm64` (a generic CPU emulation) which does not expose advanced CPU instructions (AVX, SSE4.2, …). The prebuilt `numpy` / `pandas` wheels need them.
 
-1. **Segmentation Fault on startup** — add-on crashes immediately
-2. **CBC solver error** (`local_evopt` fails with "file not found") — optimizer cannot run
-
-Both issues are caused by `kvm64` not emulating advanced CPU instructions (AVX, SSE4.2, etc.) that the CBC solver binary requires.
+> **Not this:** if `local_evopt` fails with `FileNotFoundError … solverdir/cbc/linux/i64/cbc`, that is **not** a CPU issue — see the add-on section below.
 
 **✅ Solution:**
 
@@ -116,7 +113,11 @@ After this change, EOS Connect (including `local_evopt`) will run normally and w
 
 ⚠️ **Important: Home Assistant OS Add-on (x86_64) CBC Solver**
 
-On x86_64 HAOS add-ons, the CBC solver binary bundled with `pulp` is compiled for glibc and cannot run on Alpine's musl runtime. EOS Connect now auto-detects a system-installed `cbc` (e.g. `/usr/bin/cbc` from the `coin-or-cbc` package) and prefers it over the bundled binary. Make sure your add-on version includes the native `coin-or-cbc` package; for full details see the [troubleshooting docs](https://ohAnd.github.io/EOS_connect/user-guide/index.html#troubleshooting).
+The CBC solver binary that ships inside the `pulp` package is, on x86_64 only, dynamically linked against glibc. The add-on images are Alpine-based (musl), which provides no glibc loader, so the binary cannot be started at all — Linux reports the misleading `FileNotFoundError: [Errno 2] No such file or directory` even though the file is present. aarch64 add-ons are unaffected, because the arm64 binary that `pulp` ships is statically linked.
+
+The add-on now installs a **statically linked CBC** of its own, which needs no glibc and runs on musl. Update to the latest add-on version and `local_evopt` works out of the box. EOS Connect also verifies the solver by actually executing it at startup and logs which binary it selected, so any remaining problem is visible in the log rather than surfacing as a cryptic error mid-optimization.
+
+For full details see the [troubleshooting docs](https://ohAnd.github.io/EOS_connect/user-guide/index.html#troubleshooting).
 
 **Note on SSL Certificate Verification:**
 By default, EOS Connect validates SSL certificates when connecting to Home Assistant or OpenHAB. If you use a setup with **self-signed or private CA certificates**, you can disable verification in Settings → Data Source → **SSL Ignore** (expert level, requires restart). Only enable this in **trusted private networks** where you fully control the network path. Currently, EOS Connect does not support supplying custom root CA certificates — this feature is planned for future releases. For production setups, we recommend obtaining a valid certificate through Let's Encrypt (free) or your organization's certificate authority.

--- a/docs/user-guide/index.html
+++ b/docs/user-guide/index.html
@@ -800,12 +800,13 @@ docker-compose up -d</code></pre>
                         <td>Check <code>eos_connect_web_port: 8081</code> is not in use, verify firewall rules</td>
                     </tr>
                     <tr>
-                        <td><strong>Proxmox VM Issues:</strong><br>
-                        • Segmentation Fault on startup<br>
-                        • local_evopt fails: "CBC file not found"</td>
+                        <td><strong>Proxmox VM Issue:</strong><br>
+                        • Segmentation Fault on startup</td>
                         <td>VM using generic <code>kvm64</code> CPU emulation (default Proxmox setting)<br>
                         <br>
-                        <code>kvm64</code> does not emulate advanced CPU instructions (AVX, SSE4.2, etc.) required by the CBC solver binary.</td>
+                        <code>kvm64</code> does not emulate advanced CPU instructions (AVX, SSE4.2, etc.) required by the prebuilt <code>numpy</code> / <code>pandas</code> wheels.<br>
+                        <br>
+                        <em>Note: a <code>local_evopt</code> "CBC file not found" error is <strong>not</strong> caused by this — see the next row.</em></td>
                         <td><strong>Solution:</strong> Change VM CPU type in Proxmox:
                         <ol style="margin: 5px 0; padding-left: 20px;">
                         <li>Stop the HA VM</li>
@@ -813,7 +814,7 @@ docker-compose up -d</code></pre>
                         <li>Change Type from <code>kvm64</code> → <code>host</code></li>
                         <li>Restart the VM</li>
                         </ol>
-                        This passes through your physical CPU directly, enabling all required instructions. Both issues will be resolved.</td>
+                        This passes through your physical CPU directly, enabling all required instructions.</td>
                     </tr>
                 </tbody>
             </table>
@@ -850,14 +851,41 @@ docker-compose up -d</code></pre>
                     </tr>
                     <tr>
                         <td><strong>local_evopt fails on HAOS x86_64 add-on</strong><br>
-                        Logs show <code>CBC file not found</code> or <code>FileNotFoundError</code></td>
-                        <td>The CBC solver binary bundled with PyPI <code>pulp</code> is linked against glibc,
-                        but the Home Assistant OS add-on container uses Alpine Linux / musl.</td>
-                        <td>EOS Connect automatically prefers a system-installed <code>cbc</code>
-                        (e.g. <code>/usr/bin/cbc</code> from the Alpine <code>coin-or-cbc</code> package)
-                        when one is available, and falls back to the bundled binary only when needed.
-                        Make sure you are running an add-on version that includes the native
-                        <code>coin-or-cbc</code> package.</td>
+                        Logs show <code>FileNotFoundError: [Errno 2] No such file or directory:
+                        '.../solverdir/cbc/linux/i64/cbc'</code></td>
+                        <td>On x86_64 <em>only</em>, the CBC solver binary bundled with PyPI
+                        <code>pulp</code> is dynamically linked against glibc. The add-on container is
+                        Alpine Linux (musl), which provides no glibc loader
+                        (<code>/lib64/ld-linux-x86-64.so.2</code>), so the binary cannot be started —
+                        and Linux reports the misleading "No such file or directory" even though the
+                        file is there.<br>
+                        <br>
+                        aarch64 add-ons are unaffected: the arm64 binary <code>pulp</code> ships is
+                        statically linked. This is <strong>not</strong> a CPU/AVX issue.</td>
+                        <td><strong>Update to the latest add-on version.</strong> The add-on now
+                        installs a statically linked CBC that needs no glibc and runs on musl.<br>
+                        <br>
+                        EOS Connect verifies the solver by actually executing it at startup, and logs
+                        the binary it selected — look for
+                        <code>[OPT-LocalEVopt] Using system CBC solver: /usr/local/bin/cbc</code>.<br>
+                        <br>
+                        <em>Note:</em> installing the Alpine <code>coin-or-cbc</code> package is not a
+                        workaround — no such package exists in any Alpine repository. Adding
+                        <code>gcompat</code> does not help either, as CBC requires glibc's internal
+                        <code>__fpu_control</code> symbol which gcompat does not implement.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>local_evopt fails with</strong>
+                        <code>No runnable CBC solver found</code></td>
+                        <td>Neither a system <code>cbc</code> on <code>PATH</code> nor the binary
+                        bundled with <code>pulp</code> could be executed on this machine. The log line
+                        names the exact reason for each candidate.</td>
+                        <td>Read the two rejection reasons in the log. <em>"missing ELF interpreter"</em>
+                        means a glibc binary on a musl system — update the add-on (see the row above).
+                        <em>"killed by signal 4 (illegal instruction)"</em> means the CPU lacks
+                        instructions the binary needs — on Proxmox, switch the VM CPU type to
+                        <code>host</code>. Otherwise switch the optimization backend away from the
+                        built-in optimizer.</td>
                     </tr>
                 </tbody>
             </table>

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ packaging>=23.2
 open-meteo-solar-forecast>=0.1.22
 psutil>=7.0.0
 pymodbus>=3.0.0
-pulp>=2.7.0
+pulp>=2.7.0,<4

--- a/src/interfaces/optimization_backends/local_evopt/optimizer.py
+++ b/src/interfaces/optimization_backends/local_evopt/optimizer.py
@@ -30,7 +30,10 @@ Modifications made for EOS_connect integration (adapted from main branch, ~2025-
 - Added 'emergency_reserve' discharging strategy (end-of-horizon SOC floor)
 - Added 'emergency_reserve' fields (s_reserve) to BatteryConfig and corresponding
   penalty variable/constraint in the MILP model
-- Added gapRel to OptimizerSettings and PULP_CBC_CMD invocation (1% optimality gap)
+- Added gapRel to OptimizerSettings and the CBC invocation (1% optimality gap)
+- Solver resolution probes CBC candidates with a real execve() and prefers the
+  first that runs (system PATH, then pulp's bundled binary), because pulp's
+  bundled x86_64 CBC is glibc-linked and cannot exec on Alpine/musl
 - Per-slot tight Big-M bounds in energy-balance and battery constraints replace the
   upstream global M=1e6, tightening the LP relaxation and reducing B&B tree size
 - or 0.0 guard on pulp.value() calls in solve() to handle None results
@@ -39,6 +42,7 @@ Modifications made for EOS_connect integration (adapted from main branch, ~2025-
 
 import logging
 import shutil
+import subprocess
 from dataclasses import dataclass, field
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Optional
@@ -46,7 +50,115 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pulp
 
-logger = logging.getLogger(__name__)
+# eos_connect.py attaches its handlers to the "__main__" logger, not to root, so
+# a logging.getLogger(__name__) here propagates to a handler-less root and the
+# solver diagnostics are silently discarded.
+logger = logging.getLogger("__main__")
+
+# Seconds allowed for a CBC candidate to answer `cbc -quit`.
+CBC_PROBE_TIMEOUT_S = 15.0
+
+# Cached probe result: the CBC path to use, or None until probed. The probe
+# forks a subprocess and solves run on a timer, so it must happen only once.
+_resolved_cbc: Optional[str] = None
+
+
+class CbcSolverUnavailableError(RuntimeError):
+    """No runnable CBC binary could be found for the built-in optimizer."""
+
+
+def _cbc_runs(path: str) -> Optional[str]:
+    """
+    Return None if `path` can actually be executed, else a rejection reason.
+
+    Executing the candidate is required, not optional: pulp's
+    COIN_CMD.available() only does os.path.exists() + os.access(X_OK), so on
+    Alpine/musl the glibc-linked CBC bundled in the pulp wheel passes that
+    check and then fails at solve time with a bare
+    "FileNotFoundError: .../solverdir/cbc/linux/i64/cbc" -- the file exists,
+    but its ELF interpreter /lib64/ld-linux-x86-64.so.2 does not.
+    """
+    try:
+        proc = subprocess.run(
+            [path, "-quit"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=CBC_PROBE_TIMEOUT_S,
+            check=False,
+        )
+    except FileNotFoundError:
+        return (
+            f"{path}: exists but cannot be started - missing ELF interpreter "
+            "(a glibc-linked binary on a musl system, e.g. Alpine Linux / "
+            "Home Assistant OS add-on)"
+        )
+    except OSError as exc:
+        return f"{path}: could not be started ({exc})"
+    except subprocess.TimeoutExpired:
+        return f"{path}: no response within {CBC_PROBE_TIMEOUT_S:.0f}s"
+    if proc.returncode < 0:
+        return (
+            f"{path}: killed by signal {-proc.returncode} "
+            "(signal 4 = illegal instruction: the binary needs CPU features "
+            "this machine does not provide, e.g. Proxmox kvm64/qemu64)"
+        )
+    if proc.returncode != 0:
+        return f"{path}: exited with status {proc.returncode}"
+    return None
+
+
+def _bundled_cbc_path() -> Optional[str]:
+    """Path of the CBC binary shipped inside the installed pulp wheel, if any."""
+    cls = getattr(pulp, "PULP_CBC_CMD", None)  # removed in PuLP 4.0
+    if cls is None:
+        return None
+    # Read the class attribute rather than instantiating, to avoid PuLP 3.x's
+    # "PULP_CBC_CMD will be removed in PuLP 4.0" deprecation warning.
+    return getattr(cls, "pulp_cbc_path", None)
+
+
+def probe_cbc_solver() -> str:
+    """
+    Determine once which CBC binary to use, logging the decision and any
+    rejections, and return its path.
+
+    Preference order:
+      1. a system `cbc` on PATH  -- lets an image ship a working build
+      2. the CBC bundled with pulp -- the historical default; fine on glibc
+
+    Both candidates must survive a real execve() probe, so a broken system
+    `cbc` no longer shadows a working bundled binary.
+    """
+    global _resolved_cbc  # pylint: disable=global-statement
+    if _resolved_cbc is not None:
+        return _resolved_cbc
+
+    rejections = []
+    candidates = (
+        ("system", shutil.which("cbc")),
+        ("bundled", _bundled_cbc_path()),
+    )
+    for label, path in candidates:
+        if not path:
+            logger.debug("[OPT-LocalEVopt] No %s CBC binary found", label)
+            continue
+        reason = _cbc_runs(path)
+        if reason is None:
+            logger.info("[OPT-LocalEVopt] Using %s CBC solver: %s", label, path)
+            _resolved_cbc = path
+            return path
+        rejections.append(f"{label} CBC -> {reason}")
+        logger.warning("[OPT-LocalEVopt] Rejected %s CBC -- %s", label, reason)
+
+    raise CbcSolverUnavailableError(
+        "No runnable CBC solver found for the built-in optimizer (local_evopt).\n"
+        + ("\n".join(f"  - {r}" for r in rejections) or "  - no CBC binary found at all")
+        + "\nOn Home Assistant OS x86_64 add-ons the CBC binary bundled with pulp "
+        "is glibc-linked and cannot run on Alpine/musl; update to an add-on "
+        "version that ships a static CBC solver, or switch the optimization "
+        "backend away from the built-in optimizer in Settings."
+    )
 
 
 def _resolve_cbc_solver(
@@ -56,29 +168,14 @@ def _resolve_cbc_solver(
     gapRel: Optional[float] = None,
 ) -> pulp.LpSolver:
     """
-    Return a PuLP CBC solver instance, preferring a system CBC binary.
+    Return a configured PuLP CBC solver bound to a verified-runnable binary.
 
-    The CBC binary bundled with the PyPI `pulp` package on x86_64 is linked
-    against glibc and fails on Alpine Linux / musl (e.g. Home Assistant OS
-    add-ons). If a system `cbc` executable is available on PATH, use it so
-    Alpine's `coin-or-cbc` package can take over. Otherwise fall back to the
-    bundled binary, which works on Debian/glibc native Docker images.
+    COIN_CMD is used for both candidates: it is PULP_CBC_CMD's own base class
+    with an identical solve path, it accepts an explicit path, and it survives
+    PuLP 4.0 dropping PULP_CBC_CMD.
     """
-    system_cbc = shutil.which("cbc")
-    if system_cbc:
-        logger.info("Using system CBC solver: %s", system_cbc)
-        # PULP_CBC_CMD does not accept a custom path in current PuLP versions;
-        # use COIN_CMD (its underlying implementation) for a system executable.
-        return pulp.COIN_CMD(
-            path=system_cbc,
-            msg=msg,
-            threads=num_threads,
-            timeLimit=time_limit,
-            gapRel=gapRel,
-        )
-
-    logger.info("No system CBC solver found; using PuLP bundled CBC")
-    return pulp.PULP_CBC_CMD(
+    return pulp.COIN_CMD(
+        path=probe_cbc_solver(),
         msg=msg,
         threads=num_threads,
         timeLimit=time_limit,

--- a/src/interfaces/optimization_backends/optimization_backend_local_evopt.py
+++ b/src/interfaces/optimization_backends/optimization_backend_local_evopt.py
@@ -18,11 +18,13 @@ import time
 from .optimization_backend_evopt import EVOptBackend
 from .local_evopt.optimizer import (
     BatteryConfig,
+    CbcSolverUnavailableError,
     GridConfig,
     OptimizationStrategy,
     Optimizer,
     OptimizerSettings,
     TimeSeriesData,
+    probe_cbc_solver,
 )
 
 logger = logging.getLogger("__main__")
@@ -53,6 +55,8 @@ class LocalEVOptBackend(EVOptBackend):
         time_zone:                pytz timezone for time calculations.
         num_threads:              CBC solver thread count (None = auto).
         time_limit:               CBC solver time limit in seconds (None = unlimited).
+                                  The CBC binary is resolved at construction time; see
+                                  local_evopt.optimizer.probe_cbc_solver().
         charging_strategy:        Strategy string for charging preferences.
         discharging_strategy:     Strategy string for discharging preferences.
         emergency_reserve_pct:    Minimum battery SOC at end-of-horizon (0-80 %).
@@ -94,6 +98,14 @@ class LocalEVOptBackend(EVOptBackend):
         # Initialize rolling average runtime tracking (5-element circular buffer)
         self.last_optimization_runtimes = [0.0] * 5
         self.last_optimization_runtime_number = 0
+        # Resolve the CBC binary now rather than on first solve: the probe forks a
+        # subprocess, and doing it inside the first solve would both hide the
+        # result from the startup log and inflate the rolling-average seed below.
+        try:
+            self.cbc_path = probe_cbc_solver()
+        except CbcSolverUnavailableError as exc:
+            self.cbc_path = None
+            logger.error("[OPT-LocalEVopt] %s", exc)
 
     def optimize(self, eos_request, timeout=180):
         """
@@ -143,10 +155,11 @@ class LocalEVOptBackend(EVOptBackend):
             elapsed = time.time() - start_time
             minutes, seconds = divmod(elapsed, 60)
             logger.info(
-                "[OPT-LocalEVopt] Solved in %d min %.2f sec — status: %s",
+                "[OPT-LocalEVopt] Solved in %d min %.2f sec — status: %s (cbc: %s)",
                 int(minutes),
                 seconds,
                 evopt_response.get("status", "unknown"),
+                self.cbc_path or "unresolved",
             )
 
             # Update rolling average runtime
@@ -175,12 +188,17 @@ class LocalEVOptBackend(EVOptBackend):
             )
             return eos_response, avg_runtime
 
+        except CbcSolverUnavailableError as exc:
+            # Already logged in full at construction time; keep the cyclic log terse
+            # but still hand the actionable message to the UI.
+            logger.error("[OPT-LocalEVopt] %s", exc)
+            return {"error": str(exc)}, None
         except ImportError as exc:
             logger.error(
                 "[OPT-LocalEVopt] PuLP is not installed — cannot run local optimizer. "
-                "Install it with: pip install pulp>=2.7.0 — error: %s", exc
+                "Install it with: pip install 'pulp>=2.7.0,<4' — error: %s", exc
             )
-            return {"error": "PuLP not installed — run: pip install pulp>=2.7.0"}, None
+            return {"error": "PuLP not installed — run: pip install 'pulp>=2.7.0,<4'"}, None
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("[OPT-LocalEVopt] Optimization failed: %s", exc, exc_info=True)
             return {"error": f"Local optimizer failed: {exc}"}, None

--- a/tests/interfaces/optimization_backends/test_optimization_backend_local_evopt.py
+++ b/tests/interfaces/optimization_backends/test_optimization_backend_local_evopt.py
@@ -18,21 +18,41 @@ Usage:
 
 # pylint: disable=protected-access
 
+import subprocess
+from datetime import datetime as _real_datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 import pulp
 import pytz
-from datetime import datetime as _real_datetime
-from unittest.mock import patch
 
 from src.interfaces.optimization_backends.optimization_backend_local_evopt import LocalEVOptBackend
+from src.interfaces.optimization_backends.local_evopt import optimizer as _optimizer_mod
 from src.interfaces.optimization_backends.local_evopt.optimizer import (
     BatteryConfig,
+    CbcSolverUnavailableError,
     GridConfig,
     OptimizationStrategy,
     Optimizer,
     TimeSeriesData,
+    _cbc_runs,
     _resolve_cbc_solver,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cbc_probe_cache():
+    """
+    Reset the module-level CBC probe cache around every test.
+
+    The probe result is cached for the process lifetime, so without this a
+    mocked selection would leak into the tests further down this file that
+    perform real solves.
+    """
+    _optimizer_mod._resolved_cbc = None
+    yield
+    _optimizer_mod._resolved_cbc = None
 
 
 # ---------------------------------------------------------------------------
@@ -594,15 +614,17 @@ class TestOptimizerSettings:
 # 9. OptimizationInterface backend selection
 # ---------------------------------------------------------------------------
 
+_OPT = "src.interfaces.optimization_backends.local_evopt.optimizer"
+_BUNDLED_CBC = pulp.PULP_CBC_CMD.pulp_cbc_path
+
+
 class TestCbcSolverSelection:
     """Test auto-detection of system vs bundled CBC solver."""
 
     def test_uses_system_binary_when_available(self):
         """Prefer a system-installed CBC executable when present on PATH."""
-        with patch(
-            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
-            return_value="/usr/bin/cbc",
-        ):
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", return_value=None):
             solver = _resolve_cbc_solver(
                 msg=0,
                 num_threads=2,
@@ -610,7 +632,8 @@ class TestCbcSolverSelection:
                 gapRel=0.01,
             )
 
-        # A system path uses COIN_CMD (PULP_CBC_CMD rejects custom paths).
+        # Both candidates use COIN_CMD: PULP_CBC_CMD rejects custom paths, and
+        # COIN_CMD is its base class with an identical solve path.
         assert isinstance(solver, pulp.COIN_CMD)
         assert solver.path == "/usr/bin/cbc"
         assert solver.msg == 0
@@ -620,10 +643,8 @@ class TestCbcSolverSelection:
 
     def test_falls_back_to_bundled_binary_when_no_system_cbc(self):
         """Fall back to the PuLP bundled CBC when no system binary is found."""
-        with patch(
-            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
-            return_value=None,
-        ):
+        with patch(f"{_OPT}.shutil.which", return_value=None), \
+             patch(f"{_OPT}._cbc_runs", return_value=None):
             solver = _resolve_cbc_solver(
                 msg=0,
                 num_threads=4,
@@ -631,26 +652,128 @@ class TestCbcSolverSelection:
                 gapRel=0.05,
             )
 
-        assert isinstance(solver, pulp.PULP_CBC_CMD)
-        # The bundled default uses pulp's internal default path; the important
-        # thing is that we did NOT pass a system path in.
-        assert solver.path != "/usr/bin/cbc"
+        assert isinstance(solver, pulp.COIN_CMD)
+        assert solver.path == _BUNDLED_CBC
         assert solver.optionsDict.get("threads") == 4
         assert solver.timeLimit == 120.0
         assert solver.optionsDict.get("gapRel") == 0.05
 
+    def test_broken_system_cbc_does_not_shadow_bundled(self):
+        """
+        A system cbc that cannot be executed must not win over a working
+        bundled binary. Regression guard: the previous implementation trusted
+        shutil.which() without ever running the candidate.
+        """
+        def _probe(path):
+            return "boom: cannot exec" if path == "/usr/bin/cbc" else None
+
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", side_effect=_probe):
+            solver = _resolve_cbc_solver(msg=0)
+
+        assert solver.path == _BUNDLED_CBC
+
+    def test_raises_when_no_cbc_can_run(self):
+        """
+        When neither candidate executes — the Alpine/musl x86_64 case — raise an
+        actionable error instead of leaking a bare FileNotFoundError from the
+        solve (issues #260, #264, #265, #273).
+        """
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", return_value="missing ELF interpreter"):
+            with pytest.raises(CbcSolverUnavailableError) as excinfo:
+                _resolve_cbc_solver(msg=0)
+
+        message = str(excinfo.value)
+        assert "missing ELF interpreter" in message
+        assert "system CBC" in message
+        assert "bundled CBC" in message
+        # Must tell the user what to actually do about it.
+        assert "add-on" in message
+
+    def test_probe_result_is_cached(self):
+        """The probe forks a subprocess, so it must run once per process."""
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", return_value=None) as probe:
+            _resolve_cbc_solver(msg=0)
+            _resolve_cbc_solver(msg=0)
+            _resolve_cbc_solver(msg=0)
+
+        assert probe.call_count == 1
+
     def test_default_settings_forwarded(self):
         """Default OptimizerSettings values are forwarded to the solver."""
-        with patch(
-            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
-            return_value="/usr/bin/cbc",
-        ):
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", return_value=None):
             solver = _resolve_cbc_solver(msg=1)
 
         assert solver.msg == 1
         assert solver.optionsDict.get("threads") is None
         assert solver.timeLimit is None
         assert solver.optionsDict.get("gapRel") is None
+
+
+class TestCbcProbe:
+    """Test _cbc_runs() rejection reasons — no real subprocess is spawned."""
+
+    def test_accepts_clean_exit(self):
+        """A candidate that runs and exits 0 is accepted."""
+        with patch(f"{_OPT}.subprocess.run", return_value=SimpleNamespace(returncode=0)):
+            assert _cbc_runs("/usr/bin/cbc") is None
+
+    def test_missing_elf_interpreter(self):
+        """The Alpine/musl case: the file exists but execve returns ENOENT."""
+        with patch(f"{_OPT}.subprocess.run", side_effect=FileNotFoundError()):
+            reason = _cbc_runs("/opt/venv/.../solverdir/cbc/linux/i64/cbc")
+
+        assert reason is not None
+        assert "ELF interpreter" in reason
+        assert "musl" in reason
+
+    def test_illegal_instruction(self):
+        """A binary needing CPU features the host lacks (Proxmox kvm64)."""
+        with patch(f"{_OPT}.subprocess.run", return_value=SimpleNamespace(returncode=-4)):
+            reason = _cbc_runs("/usr/bin/cbc")
+
+        assert reason is not None
+        assert "signal 4" in reason
+        assert "illegal instruction" in reason
+
+    def test_nonzero_exit(self):
+        """A candidate that runs but reports failure is rejected."""
+        with patch(f"{_OPT}.subprocess.run", return_value=SimpleNamespace(returncode=1)):
+            reason = _cbc_runs("/usr/bin/cbc")
+
+        assert reason is not None
+        assert "status 1" in reason
+
+    def test_timeout(self):
+        """A candidate that hangs is rejected rather than blocking the solve."""
+        with patch(
+            f"{_OPT}.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="cbc", timeout=15.0),
+        ):
+            reason = _cbc_runs("/usr/bin/cbc")
+
+        assert reason is not None
+        assert "15s" in reason
+
+    def test_other_oserror(self):
+        """Any other OSError (e.g. permissions) is reported, not raised."""
+        with patch(f"{_OPT}.subprocess.run", side_effect=PermissionError("denied")):
+            reason = _cbc_runs("/usr/bin/cbc")
+
+        assert reason is not None
+        assert "could not be started" in reason
+
+    def test_real_bundled_binary_probe(self):
+        """
+        Sanity check against the actual installed pulp binary. On glibc CI this
+        proves the probe accepts a genuinely working CBC rather than only
+        agreeing with mocks.
+        """
+        reason = _cbc_runs(_BUNDLED_CBC)
+        assert reason is None, f"bundled CBC unexpectedly rejected: {reason}"
 
 
 class TestOptimizationInterfaceSelection:


### PR DESCRIPTION
PULP_CBC_CMD.available() only stats the file, so the glibc-linked x86_64 CBC bundled with pulp passes on Alpine/musl and then fails at solve time. Execute the candidate instead, and fall back to the bundled binary when a broken system cbc is on PATH.

Also fixes the solver logger, which wrote to a handler-less logger and hid the solver choice from every bug report so far. Corrects README/docs: the failure is not an AVX issue, and the Alpine coin-or-cbc package it told users to install does not exist.

Fixes: #260 #264 #265 #273