### PR TITLE
Release v0.3.37 — CBC solver fixes, EVCC forecast support, PV config fix

### DIFF
--- a/.github/workflows/docker_develop.yml
+++ b/.github/workflows/docker_develop.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch: # allows manual triggering of the workflow
 
 env:
-  VERSION_PREFIX: 0.3.36.
+  VERSION_PREFIX: 0.3.37.
   VERSION_SUFFIX: -develop
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test_config_ui.py
 *.db
 *.db-wal
 *.db-shm
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ After this change, EOS Connect (including `local_evopt`) will run normally and w
 
 **Note:** Changing to `host` CPU type is safe and recommended for all Proxmox VMs running containerized applications that require native CPU features.
 
+⚠️ **Important: Home Assistant OS Add-on (x86_64) CBC Solver**
+
+On x86_64 HAOS add-ons, the CBC solver binary bundled with `pulp` is compiled for glibc and cannot run on Alpine's musl runtime. EOS Connect now auto-detects a system-installed `cbc` (e.g. `/usr/bin/cbc` from the `coin-or-cbc` package) and prefers it over the bundled binary. Make sure your add-on version includes the native `coin-or-cbc` package; for full details see the [troubleshooting docs](https://ohAnd.github.io/EOS_connect/user-guide/index.html#troubleshooting).
+
 **Note on SSL Certificate Verification:**
 By default, EOS Connect validates SSL certificates when connecting to Home Assistant or OpenHAB. If you use a setup with **self-signed or private CA certificates**, you can disable verification in Settings → Data Source → **SSL Ignore** (expert level, requires restart). Only enable this in **trusted private networks** where you fully control the network path. Currently, EOS Connect does not support supplying custom root CA certificates — this feature is planned for future releases. For production setups, we recommend obtaining a valid certificate through Let's Encrypt (free) or your organization's certificate authority.
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,9 @@ Supported data sources and integrations:
 
 ⚠️ **Important: Proxmox / KVM64 CPU Limitation**
 
-If you experience issues with EOS Connect on **Proxmox** with the default CPU type, your VM is likely using `kvm64` (a generic CPU emulation). This can cause two types of failures:
+If EOS Connect **crashes with a segmentation fault on startup** on **Proxmox** with the default CPU type, your VM is likely using `kvm64` (a generic CPU emulation) which does not expose advanced CPU instructions (AVX, SSE4.2, …). The prebuilt `numpy` / `pandas` wheels need them.
 
-1. **Segmentation Fault on startup** — add-on crashes immediately
-2. **CBC solver error** (`local_evopt` fails with "file not found") — optimizer cannot run
-
-Both issues are caused by `kvm64` not emulating advanced CPU instructions (AVX, SSE4.2, etc.) that the CBC solver binary requires.
+> **Not this:** if `local_evopt` fails with `FileNotFoundError … solverdir/cbc/linux/i64/cbc`, that is **not** a CPU issue — see the add-on section below.
 
 **✅ Solution:**
 
@@ -116,7 +113,11 @@ After this change, EOS Connect (including `local_evopt`) will run normally and w
 
 ⚠️ **Important: Home Assistant OS Add-on (x86_64) CBC Solver**
 
-On x86_64 HAOS add-ons, the CBC solver binary bundled with `pulp` is compiled for glibc and cannot run on Alpine's musl runtime. EOS Connect now auto-detects a system-installed `cbc` (e.g. `/usr/bin/cbc` from the `coin-or-cbc` package) and prefers it over the bundled binary. Make sure your add-on version includes the native `coin-or-cbc` package; for full details see the [troubleshooting docs](https://ohAnd.github.io/EOS_connect/user-guide/index.html#troubleshooting).
+The CBC solver binary that ships inside the `pulp` package is, on x86_64 only, dynamically linked against glibc. The add-on images are Alpine-based (musl), which provides no glibc loader, so the binary cannot be started at all — Linux reports the misleading `FileNotFoundError: [Errno 2] No such file or directory` even though the file is present. aarch64 add-ons are unaffected, because the arm64 binary that `pulp` ships is statically linked.
+
+The add-on now installs a **statically linked CBC** of its own, which needs no glibc and runs on musl. Update to the latest add-on version and `local_evopt` works out of the box. EOS Connect also verifies the solver by actually executing it at startup and logs which binary it selected, so any remaining problem is visible in the log rather than surfacing as a cryptic error mid-optimization.
+
+For full details see the [troubleshooting docs](https://ohAnd.github.io/EOS_connect/user-guide/index.html#troubleshooting).
 
 **Note on SSL Certificate Verification:**
 By default, EOS Connect validates SSL certificates when connecting to Home Assistant or OpenHAB. If you use a setup with **self-signed or private CA certificates**, you can disable verification in Settings → Data Source → **SSL Ignore** (expert level, requires restart). Only enable this in **trusted private networks** where you fully control the network path. Currently, EOS Connect does not support supplying custom root CA certificates — this feature is planned for future releases. For production setups, we recommend obtaining a valid certificate through Let's Encrypt (free) or your organization's certificate authority.

--- a/docs/advanced/index.html
+++ b/docs/advanced/index.html
@@ -19,7 +19,7 @@
             <a href="../index.html" class="nav-logo">
                 <img src="../assets/images/icon.png" alt="EOS Connect" style="height: 48px; vertical-align: middle; margin-right: 8px;">
                 <span>EOS Connect</span>
-                <span class="version-badge">v0.3.36</span>
+                <span class="version-badge">v0.3.37</span>
             </a>
             <button class="mobile-menu-toggle" onclick="toggleMobileMenu()" aria-label="Toggle menu">
                 <i class="fas fa-bars"></i>

--- a/docs/developer/index.html
+++ b/docs/developer/index.html
@@ -19,7 +19,7 @@
             <a href="../index.html" class="nav-logo">
                 <img src="../assets/images/icon.png" alt="EOS Connect" style="height: 48px; vertical-align: middle; margin-right: 8px;">
                 <span>EOS Connect</span>
-                <span class="version-badge">v0.3.36</span>
+                <span class="version-badge">v0.3.37</span>
             </a>
             <button class="mobile-menu-toggle" onclick="toggleMobileMenu()" aria-label="Toggle menu">
                 <i class="fas fa-bars"></i>

--- a/docs/developer/index.html
+++ b/docs/developer/index.html
@@ -507,6 +507,14 @@ pytest --cov=src tests/
 # Run with verbose output
 pytest -v tests/</code></pre>
 
+            <h3>EVCC Forecast Compatibility</h3>
+            <p>
+                The PV interface accepts both legacy EVCC forecast entries (<code>{ts, val}</code>) and the
+                compact wire format introduced by EVCC (<code>[unix_timestamp, value]</code>). Unix timestamps
+                in seconds and milliseconds are supported. EVCC values are power in watts for 15-minute slots
+                and are converted to Wh before the common PV forecast array is built.
+            </p>
+
             <h3>Writing Tests</h3>
             <h4>Test File Naming</h4>
             <ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
             <a href="index.html" class="nav-logo">
                 <img src="assets/images/icon.png" alt="EOS Connect" style="height: 48px; vertical-align: middle; margin-right: 8px;">
                 <span>EOS Connect</span>
-                <span class="version-badge">v0.3.36</span>
+                <span class="version-badge">v0.3.37</span>
             </a>
             <button class="mobile-menu-toggle" onclick="toggleMobileMenu()" aria-label="Toggle menu">
                 <i class="fas fa-bars"></i>

--- a/docs/user-guide/configuration.html
+++ b/docs/user-guide/configuration.html
@@ -20,7 +20,7 @@
             <a href="../index.html" class="nav-logo">
                 <img src="../assets/images/icon.png" alt="EOS Connect" style="height: 48px; vertical-align: middle; margin-right: 8px;">
                 <span>EOS Connect</span>
-                <span class="version-badge">v0.3.36</span>
+                <span class="version-badge">v0.3.37</span>
             </a>
             <button class="mobile-menu-toggle" onclick="toggleMobileMenu()" aria-label="Toggle menu">
                 <i class="fas fa-bars"></i>

--- a/docs/user-guide/index.html
+++ b/docs/user-guide/index.html
@@ -848,6 +848,17 @@ docker-compose up -d</code></pre>
                         <td>Incorrect EOS prediction mode</td>
                         <td>Verify EOS is in prediction mode, not simulation</td>
                     </tr>
+                    <tr>
+                        <td><strong>local_evopt fails on HAOS x86_64 add-on</strong><br>
+                        Logs show <code>CBC file not found</code> or <code>FileNotFoundError</code></td>
+                        <td>The CBC solver binary bundled with PyPI <code>pulp</code> is linked against glibc,
+                        but the Home Assistant OS add-on container uses Alpine Linux / musl.</td>
+                        <td>EOS Connect automatically prefers a system-installed <code>cbc</code>
+                        (e.g. <code>/usr/bin/cbc</code> from the Alpine <code>coin-or-cbc</code> package)
+                        when one is available, and falls back to the bundled binary only when needed.
+                        Make sure you are running an add-on version that includes the native
+                        <code>coin-or-cbc</code> package.</td>
+                    </tr>
                 </tbody>
             </table>
 

--- a/docs/user-guide/index.html
+++ b/docs/user-guide/index.html
@@ -19,7 +19,7 @@
             <a href="../index.html" class="nav-logo">
                 <img src="../assets/images/icon.png" alt="EOS Connect" style="height: 48px; vertical-align: middle; margin-right: 8px;">
                 <span>EOS Connect</span>
-                <span class="version-badge">v0.3.36</span>
+                <span class="version-badge">v0.3.37</span>
             </a>
             <button class="mobile-menu-toggle" onclick="toggleMobileMenu()" aria-label="Toggle menu">
                 <i class="fas fa-bars"></i>

--- a/docs/user-guide/index.html
+++ b/docs/user-guide/index.html
@@ -800,12 +800,13 @@ docker-compose up -d</code></pre>
                         <td>Check <code>eos_connect_web_port: 8081</code> is not in use, verify firewall rules</td>
                     </tr>
                     <tr>
-                        <td><strong>Proxmox VM Issues:</strong><br>
-                        • Segmentation Fault on startup<br>
-                        • local_evopt fails: "CBC file not found"</td>
+                        <td><strong>Proxmox VM Issue:</strong><br>
+                        • Segmentation Fault on startup</td>
                         <td>VM using generic <code>kvm64</code> CPU emulation (default Proxmox setting)<br>
                         <br>
-                        <code>kvm64</code> does not emulate advanced CPU instructions (AVX, SSE4.2, etc.) required by the CBC solver binary.</td>
+                        <code>kvm64</code> does not emulate advanced CPU instructions (AVX, SSE4.2, etc.) required by the prebuilt <code>numpy</code> / <code>pandas</code> wheels.<br>
+                        <br>
+                        <em>Note: a <code>local_evopt</code> "CBC file not found" error is <strong>not</strong> caused by this — see the next row.</em></td>
                         <td><strong>Solution:</strong> Change VM CPU type in Proxmox:
                         <ol style="margin: 5px 0; padding-left: 20px;">
                         <li>Stop the HA VM</li>
@@ -813,7 +814,7 @@ docker-compose up -d</code></pre>
                         <li>Change Type from <code>kvm64</code> → <code>host</code></li>
                         <li>Restart the VM</li>
                         </ol>
-                        This passes through your physical CPU directly, enabling all required instructions. Both issues will be resolved.</td>
+                        This passes through your physical CPU directly, enabling all required instructions.</td>
                     </tr>
                 </tbody>
             </table>
@@ -850,14 +851,41 @@ docker-compose up -d</code></pre>
                     </tr>
                     <tr>
                         <td><strong>local_evopt fails on HAOS x86_64 add-on</strong><br>
-                        Logs show <code>CBC file not found</code> or <code>FileNotFoundError</code></td>
-                        <td>The CBC solver binary bundled with PyPI <code>pulp</code> is linked against glibc,
-                        but the Home Assistant OS add-on container uses Alpine Linux / musl.</td>
-                        <td>EOS Connect automatically prefers a system-installed <code>cbc</code>
-                        (e.g. <code>/usr/bin/cbc</code> from the Alpine <code>coin-or-cbc</code> package)
-                        when one is available, and falls back to the bundled binary only when needed.
-                        Make sure you are running an add-on version that includes the native
-                        <code>coin-or-cbc</code> package.</td>
+                        Logs show <code>FileNotFoundError: [Errno 2] No such file or directory:
+                        '.../solverdir/cbc/linux/i64/cbc'</code></td>
+                        <td>On x86_64 <em>only</em>, the CBC solver binary bundled with PyPI
+                        <code>pulp</code> is dynamically linked against glibc. The add-on container is
+                        Alpine Linux (musl), which provides no glibc loader
+                        (<code>/lib64/ld-linux-x86-64.so.2</code>), so the binary cannot be started —
+                        and Linux reports the misleading "No such file or directory" even though the
+                        file is there.<br>
+                        <br>
+                        aarch64 add-ons are unaffected: the arm64 binary <code>pulp</code> ships is
+                        statically linked. This is <strong>not</strong> a CPU/AVX issue.</td>
+                        <td><strong>Update to the latest add-on version.</strong> The add-on now
+                        installs a statically linked CBC that needs no glibc and runs on musl.<br>
+                        <br>
+                        EOS Connect verifies the solver by actually executing it at startup, and logs
+                        the binary it selected — look for
+                        <code>[OPT-LocalEVopt] Using system CBC solver: /usr/local/bin/cbc</code>.<br>
+                        <br>
+                        <em>Note:</em> installing the Alpine <code>coin-or-cbc</code> package is not a
+                        workaround — no such package exists in any Alpine repository. Adding
+                        <code>gcompat</code> does not help either, as CBC requires glibc's internal
+                        <code>__fpu_control</code> symbol which gcompat does not implement.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>local_evopt fails with</strong>
+                        <code>No runnable CBC solver found</code></td>
+                        <td>Neither a system <code>cbc</code> on <code>PATH</code> nor the binary
+                        bundled with <code>pulp</code> could be executed on this machine. The log line
+                        names the exact reason for each candidate.</td>
+                        <td>Read the two rejection reasons in the log. <em>"missing ELF interpreter"</em>
+                        means a glibc binary on a musl system — update the add-on (see the row above).
+                        <em>"killed by signal 4 (illegal instruction)"</em> means the CPU lacks
+                        instructions the binary needs — on Proxmox, switch the VM CPU type to
+                        <code>host</code>. Otherwise switch the optimization backend away from the
+                        built-in optimizer.</td>
                     </tr>
                 </tbody>
             </table>

--- a/docs/what-is/index.html
+++ b/docs/what-is/index.html
@@ -20,7 +20,7 @@
             <a href="../index.html" class="nav-logo">
                 <img src="../assets/images/icon.png" alt="EOS Connect" style="height: 48px; vertical-align: middle; margin-right: 8px;">
                 <span>EOS Connect</span>
-                <span class="version-badge">v0.3.36</span>
+                <span class="version-badge">v0.3.37</span>
             </a>
             <button class="mobile-menu-toggle" onclick="toggleMobileMenu()" aria-label="Toggle menu">
                 <i class="fas fa-bars"></i>

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ packaging>=23.2
 open-meteo-solar-forecast>=0.1.22
 psutil>=7.0.0
 pymodbus>=3.0.0
-pulp>=2.7.0
+pulp>=2.7.0,<4

--- a/src/config_web/api.py
+++ b/src/config_web/api.py
@@ -142,15 +142,6 @@ def update_config():
     if errors:
         return jsonify({"errors": errors}), 422
 
-    # Check cross-field dependencies (these don't block, but are returned as unmet_dependencies)
-    unmet_deps = _check_dependencies(data)
-    if unmet_deps:
-        return jsonify({
-            "success": False,
-            "unmet_dependencies": unmet_deps,
-            "message": "Cannot save: required dependencies not configured"
-        }), 200
-
     # Check for timeseries configuration changes and run pre-flight validation if needed
     preflight_errors = _check_timeseries_preflight(data)
     if preflight_errors:
@@ -181,6 +172,16 @@ def update_config():
 
     # Rebuild merged config so get_config() reflects changes
     _module.rebuild_config()
+
+    # Check cross-field dependencies after the new config has been merged.
+    # This ensures array updates like pv_forecast.0.* are visible to dependency logic.
+    unmet_deps = _check_dependencies(data)
+    if unmet_deps:
+        return jsonify({
+            "success": False,
+            "unmet_dependencies": unmet_deps,
+            "message": "Cannot save: required dependencies not configured"
+        }), 200
 
     # Persist restart-required fields for banner across reloads
     if restart_required:

--- a/src/config_web/merger.py
+++ b/src/config_web/merger.py
@@ -8,6 +8,7 @@ from the SQLite store. Resolves the unified ``data_source`` into per-section
 """
 
 import logging
+import re
 from typing import Any
 
 from .store import ConfigStore
@@ -159,6 +160,25 @@ def _build_pv_forecast(
                     entry[field_name] = field_def.default
             result_list.append(entry)
         return result_list
+
+    # Try format 1.5: unindexed template keys like pv_forecast.name, pv_forecast.lat
+    template_entry = {}
+    for key, value in all_settings.items():
+        if key.startswith("pv_forecast.") and not re.match(r"^pv_forecast\.\d+\.", key):
+            parts = key.split(".")
+            if len(parts) == 2:
+                template_entry[parts[1]] = value
+
+    if template_entry:
+        logger.warning(
+            "[Merger] Found unindexed pv_forecast template keys in the store; synthesizing one installation"
+        )
+        entry = template_entry.copy()
+        for field_def in schema.get_section("pv_forecast"):
+            field_name = field_def.key.split(".")[-1]
+            if field_name not in entry:
+                entry[field_name] = field_def.default
+        return [entry]
 
     # Try format 2: single key (from migration) — fallback
     if "pv_forecast" in all_settings:

--- a/src/interfaces/optimization_backends/local_evopt/optimizer.py
+++ b/src/interfaces/optimization_backends/local_evopt/optimizer.py
@@ -37,12 +37,53 @@ Modifications made for EOS_connect integration (adapted from main branch, ~2025-
 - Module is invoked in-process; no HTTP server needed
 """
 
+import logging
+import shutil
 from dataclasses import dataclass, field
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pulp
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_cbc_solver(
+    msg: int = 0,
+    num_threads: Optional[int] = None,
+    time_limit: Optional[float] = None,
+    gapRel: Optional[float] = None,
+) -> pulp.LpSolver:
+    """
+    Return a PuLP CBC solver instance, preferring a system CBC binary.
+
+    The CBC binary bundled with the PyPI `pulp` package on x86_64 is linked
+    against glibc and fails on Alpine Linux / musl (e.g. Home Assistant OS
+    add-ons). If a system `cbc` executable is available on PATH, use it so
+    Alpine's `coin-or-cbc` package can take over. Otherwise fall back to the
+    bundled binary, which works on Debian/glibc native Docker images.
+    """
+    system_cbc = shutil.which("cbc")
+    if system_cbc:
+        logger.info("Using system CBC solver: %s", system_cbc)
+        # PULP_CBC_CMD does not accept a custom path in current PuLP versions;
+        # use COIN_CMD (its underlying implementation) for a system executable.
+        return pulp.COIN_CMD(
+            path=system_cbc,
+            msg=msg,
+            threads=num_threads,
+            timeLimit=time_limit,
+            gapRel=gapRel,
+        )
+
+    logger.info("No system CBC solver found; using PuLP bundled CBC")
+    return pulp.PULP_CBC_CMD(
+        msg=msg,
+        threads=num_threads,
+        timeLimit=time_limit,
+        gapRel=gapRel,
+    )
 
 
 @dataclass
@@ -704,10 +745,10 @@ class Optimizer:
         if self.problem is None:
             self.create_model()
 
-        solver = pulp.PULP_CBC_CMD(
+        solver = _resolve_cbc_solver(
             msg=0,
-            threads=self.settings.num_threads,
-            timeLimit=self.settings.time_limit,
+            num_threads=self.settings.num_threads,
+            time_limit=self.settings.time_limit,
             gapRel=self.settings.gapRel,
         )
 

--- a/src/interfaces/optimization_backends/local_evopt/optimizer.py
+++ b/src/interfaces/optimization_backends/local_evopt/optimizer.py
@@ -30,7 +30,10 @@ Modifications made for EOS_connect integration (adapted from main branch, ~2025-
 - Added 'emergency_reserve' discharging strategy (end-of-horizon SOC floor)
 - Added 'emergency_reserve' fields (s_reserve) to BatteryConfig and corresponding
   penalty variable/constraint in the MILP model
-- Added gapRel to OptimizerSettings and PULP_CBC_CMD invocation (1% optimality gap)
+- Added gapRel to OptimizerSettings and the CBC invocation (1% optimality gap)
+- Solver resolution probes CBC candidates with a real execve() and prefers the
+  first that runs (system PATH, then pulp's bundled binary), because pulp's
+  bundled x86_64 CBC is glibc-linked and cannot exec on Alpine/musl
 - Per-slot tight Big-M bounds in energy-balance and battery constraints replace the
   upstream global M=1e6, tightening the LP relaxation and reducing B&B tree size
 - or 0.0 guard on pulp.value() calls in solve() to handle None results
@@ -39,6 +42,7 @@ Modifications made for EOS_connect integration (adapted from main branch, ~2025-
 
 import logging
 import shutil
+import subprocess
 from dataclasses import dataclass, field
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Optional
@@ -46,7 +50,115 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pulp
 
-logger = logging.getLogger(__name__)
+# eos_connect.py attaches its handlers to the "__main__" logger, not to root, so
+# a logging.getLogger(__name__) here propagates to a handler-less root and the
+# solver diagnostics are silently discarded.
+logger = logging.getLogger("__main__")
+
+# Seconds allowed for a CBC candidate to answer `cbc -quit`.
+CBC_PROBE_TIMEOUT_S = 15.0
+
+# Cached probe result: the CBC path to use, or None until probed. The probe
+# forks a subprocess and solves run on a timer, so it must happen only once.
+_resolved_cbc: Optional[str] = None
+
+
+class CbcSolverUnavailableError(RuntimeError):
+    """No runnable CBC binary could be found for the built-in optimizer."""
+
+
+def _cbc_runs(path: str) -> Optional[str]:
+    """
+    Return None if `path` can actually be executed, else a rejection reason.
+
+    Executing the candidate is required, not optional: pulp's
+    COIN_CMD.available() only does os.path.exists() + os.access(X_OK), so on
+    Alpine/musl the glibc-linked CBC bundled in the pulp wheel passes that
+    check and then fails at solve time with a bare
+    "FileNotFoundError: .../solverdir/cbc/linux/i64/cbc" -- the file exists,
+    but its ELF interpreter /lib64/ld-linux-x86-64.so.2 does not.
+    """
+    try:
+        proc = subprocess.run(
+            [path, "-quit"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=CBC_PROBE_TIMEOUT_S,
+            check=False,
+        )
+    except FileNotFoundError:
+        return (
+            f"{path}: exists but cannot be started - missing ELF interpreter "
+            "(a glibc-linked binary on a musl system, e.g. Alpine Linux / "
+            "Home Assistant OS add-on)"
+        )
+    except OSError as exc:
+        return f"{path}: could not be started ({exc})"
+    except subprocess.TimeoutExpired:
+        return f"{path}: no response within {CBC_PROBE_TIMEOUT_S:.0f}s"
+    if proc.returncode < 0:
+        return (
+            f"{path}: killed by signal {-proc.returncode} "
+            "(signal 4 = illegal instruction: the binary needs CPU features "
+            "this machine does not provide, e.g. Proxmox kvm64/qemu64)"
+        )
+    if proc.returncode != 0:
+        return f"{path}: exited with status {proc.returncode}"
+    return None
+
+
+def _bundled_cbc_path() -> Optional[str]:
+    """Path of the CBC binary shipped inside the installed pulp wheel, if any."""
+    cls = getattr(pulp, "PULP_CBC_CMD", None)  # removed in PuLP 4.0
+    if cls is None:
+        return None
+    # Read the class attribute rather than instantiating, to avoid PuLP 3.x's
+    # "PULP_CBC_CMD will be removed in PuLP 4.0" deprecation warning.
+    return getattr(cls, "pulp_cbc_path", None)
+
+
+def probe_cbc_solver() -> str:
+    """
+    Determine once which CBC binary to use, logging the decision and any
+    rejections, and return its path.
+
+    Preference order:
+      1. a system `cbc` on PATH  -- lets an image ship a working build
+      2. the CBC bundled with pulp -- the historical default; fine on glibc
+
+    Both candidates must survive a real execve() probe, so a broken system
+    `cbc` no longer shadows a working bundled binary.
+    """
+    global _resolved_cbc  # pylint: disable=global-statement
+    if _resolved_cbc is not None:
+        return _resolved_cbc
+
+    rejections = []
+    candidates = (
+        ("system", shutil.which("cbc")),
+        ("bundled", _bundled_cbc_path()),
+    )
+    for label, path in candidates:
+        if not path:
+            logger.debug("[OPT-LocalEVopt] No %s CBC binary found", label)
+            continue
+        reason = _cbc_runs(path)
+        if reason is None:
+            logger.info("[OPT-LocalEVopt] Using %s CBC solver: %s", label, path)
+            _resolved_cbc = path
+            return path
+        rejections.append(f"{label} CBC -> {reason}")
+        logger.warning("[OPT-LocalEVopt] Rejected %s CBC -- %s", label, reason)
+
+    raise CbcSolverUnavailableError(
+        "No runnable CBC solver found for the built-in optimizer (local_evopt).\n"
+        + ("\n".join(f"  - {r}" for r in rejections) or "  - no CBC binary found at all")
+        + "\nOn Home Assistant OS x86_64 add-ons the CBC binary bundled with pulp "
+        "is glibc-linked and cannot run on Alpine/musl; update to an add-on "
+        "version that ships a static CBC solver, or switch the optimization "
+        "backend away from the built-in optimizer in Settings."
+    )
 
 
 def _resolve_cbc_solver(
@@ -56,29 +168,14 @@ def _resolve_cbc_solver(
     gapRel: Optional[float] = None,
 ) -> pulp.LpSolver:
     """
-    Return a PuLP CBC solver instance, preferring a system CBC binary.
+    Return a configured PuLP CBC solver bound to a verified-runnable binary.
 
-    The CBC binary bundled with the PyPI `pulp` package on x86_64 is linked
-    against glibc and fails on Alpine Linux / musl (e.g. Home Assistant OS
-    add-ons). If a system `cbc` executable is available on PATH, use it so
-    Alpine's `coin-or-cbc` package can take over. Otherwise fall back to the
-    bundled binary, which works on Debian/glibc native Docker images.
+    COIN_CMD is used for both candidates: it is PULP_CBC_CMD's own base class
+    with an identical solve path, it accepts an explicit path, and it survives
+    PuLP 4.0 dropping PULP_CBC_CMD.
     """
-    system_cbc = shutil.which("cbc")
-    if system_cbc:
-        logger.info("Using system CBC solver: %s", system_cbc)
-        # PULP_CBC_CMD does not accept a custom path in current PuLP versions;
-        # use COIN_CMD (its underlying implementation) for a system executable.
-        return pulp.COIN_CMD(
-            path=system_cbc,
-            msg=msg,
-            threads=num_threads,
-            timeLimit=time_limit,
-            gapRel=gapRel,
-        )
-
-    logger.info("No system CBC solver found; using PuLP bundled CBC")
-    return pulp.PULP_CBC_CMD(
+    return pulp.COIN_CMD(
+        path=probe_cbc_solver(),
         msg=msg,
         threads=num_threads,
         timeLimit=time_limit,

--- a/src/interfaces/optimization_backends/optimization_backend_eos.py
+++ b/src/interfaces/optimization_backends/optimization_backend_eos.py
@@ -462,6 +462,14 @@ class EOSBackend:
                 "[OPT-EOS] 'packaging' module not found. Cannot compare EOS versions."
             )
             return False
+        except version.InvalidVersion:
+            logger.warning(
+                "[OPT-EOS] Invalid EOS version string '%s'. "
+                "Cannot compare versions. Assuming version < %s",
+                self.eos_version,
+                version_string,
+            )
+            return False
 
     def create_dataframe(self, profile):
         """

--- a/src/interfaces/optimization_backends/optimization_backend_local_evopt.py
+++ b/src/interfaces/optimization_backends/optimization_backend_local_evopt.py
@@ -18,11 +18,13 @@ import time
 from .optimization_backend_evopt import EVOptBackend
 from .local_evopt.optimizer import (
     BatteryConfig,
+    CbcSolverUnavailableError,
     GridConfig,
     OptimizationStrategy,
     Optimizer,
     OptimizerSettings,
     TimeSeriesData,
+    probe_cbc_solver,
 )
 
 logger = logging.getLogger("__main__")
@@ -53,6 +55,8 @@ class LocalEVOptBackend(EVOptBackend):
         time_zone:                pytz timezone for time calculations.
         num_threads:              CBC solver thread count (None = auto).
         time_limit:               CBC solver time limit in seconds (None = unlimited).
+                                  The CBC binary is resolved at construction time; see
+                                  local_evopt.optimizer.probe_cbc_solver().
         charging_strategy:        Strategy string for charging preferences.
         discharging_strategy:     Strategy string for discharging preferences.
         emergency_reserve_pct:    Minimum battery SOC at end-of-horizon (0-80 %).
@@ -94,6 +98,14 @@ class LocalEVOptBackend(EVOptBackend):
         # Initialize rolling average runtime tracking (5-element circular buffer)
         self.last_optimization_runtimes = [0.0] * 5
         self.last_optimization_runtime_number = 0
+        # Resolve the CBC binary now rather than on first solve: the probe forks a
+        # subprocess, and doing it inside the first solve would both hide the
+        # result from the startup log and inflate the rolling-average seed below.
+        try:
+            self.cbc_path = probe_cbc_solver()
+        except CbcSolverUnavailableError as exc:
+            self.cbc_path = None
+            logger.error("[OPT-LocalEVopt] %s", exc)
 
     def optimize(self, eos_request, timeout=180):
         """
@@ -143,10 +155,11 @@ class LocalEVOptBackend(EVOptBackend):
             elapsed = time.time() - start_time
             minutes, seconds = divmod(elapsed, 60)
             logger.info(
-                "[OPT-LocalEVopt] Solved in %d min %.2f sec — status: %s",
+                "[OPT-LocalEVopt] Solved in %d min %.2f sec — status: %s (cbc: %s)",
                 int(minutes),
                 seconds,
                 evopt_response.get("status", "unknown"),
+                self.cbc_path or "unresolved",
             )
 
             # Update rolling average runtime
@@ -175,12 +188,17 @@ class LocalEVOptBackend(EVOptBackend):
             )
             return eos_response, avg_runtime
 
+        except CbcSolverUnavailableError as exc:
+            # Already logged in full at construction time; keep the cyclic log terse
+            # but still hand the actionable message to the UI.
+            logger.error("[OPT-LocalEVopt] %s", exc)
+            return {"error": str(exc)}, None
         except ImportError as exc:
             logger.error(
                 "[OPT-LocalEVopt] PuLP is not installed — cannot run local optimizer. "
-                "Install it with: pip install pulp>=2.7.0 — error: %s", exc
+                "Install it with: pip install 'pulp>=2.7.0,<4' — error: %s", exc
             )
-            return {"error": "PuLP not installed — run: pip install pulp>=2.7.0"}, None
+            return {"error": "PuLP not installed — run: pip install 'pulp>=2.7.0,<4'"}, None
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("[OPT-LocalEVopt] Optimization failed: %s", exc, exc_info=True)
             return {"error": f"Local optimizer failed: {exc}"}, None

--- a/src/interfaces/pv_interface.py
+++ b/src/interfaces/pv_interface.py
@@ -22,7 +22,7 @@ Logging:
     and errors related to configuration, API requests, and background updates.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import threading
 import logging
 import time
@@ -1966,13 +1966,43 @@ class PvInterface:
             # --- AGGREGATE 15-min intervals to hourly Wh if needed ---
             forecast_items = []
             for item in solar_forecast:
-                ts_str = item.get("ts", "")
-                if ts_str:
-                    ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                # EVCC <= 0.312 used objects ({ts, val}); newer EVCC
+                # versions publish compact [unix_timestamp, value] arrays.
+                if isinstance(item, dict):
+                    timestamp_value = item.get("ts")
+                    power_value = item.get("val", 0)
+                elif isinstance(item, (list, tuple)) and len(item) >= 2:
+                    timestamp_value, power_value = item[0], item[1]
+                else:
+                    logger.warning("[PV-IF] Ignoring invalid EVCC forecast item: %r", item)
+                    continue
+
+                try:
+                    if isinstance(timestamp_value, (int, float)):
+                        # Unix timestamps may be published in seconds or milliseconds.
+                        timestamp_seconds = (
+                            timestamp_value / 1000.0
+                            if abs(timestamp_value) >= 1_000_000_000_000
+                            else timestamp_value
+                        )
+                        ts = datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
+                    elif isinstance(timestamp_value, str):
+                        ts = datetime.fromisoformat(timestamp_value.replace("Z", "+00:00"))
+                        if ts.tzinfo is None:
+                            ts = tz.localize(ts)
+                    else:
+                        raise ValueError("unsupported timestamp type")
+
                     ts = ts.astimezone(tz)
-                    # Convert W to Wh for 15 min: Wh = W * 0.25
-                    val_wh = item.get("val", 0) * 0.25
+                    # EVCC values are power in W for each 15-minute slot.
+                    val_wh = float(power_value) * 0.25
                     forecast_items.append((ts, val_wh))
+                except (TypeError, ValueError, OverflowError, OSError) as exc:
+                    logger.warning(
+                        "[PV-IF] Ignoring invalid EVCC forecast item %r: %s",
+                        item,
+                        exc,
+                    )
 
             if self.time_frame_base == 3600:
                 # Group by hour and sum Wh values

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.37.320-develop'
+__version__ = '0.3.37.321-develop'

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.37.321-develop'
+__version__ = '0.3.37.322-develop'

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.37'
+__version__ = '0.3.37.325-develop'

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.36.319-develop'
+__version__ = '0.3.37.320-develop'

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.37.322-develop'
+__version__ = '0.3.37.323-develop'

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.37.323-develop'
+__version__ = '0.3.37.324-develop'

--- a/src/web/js/wizard.js
+++ b/src/web/js/wizard.js
@@ -812,7 +812,7 @@ class SetupWizard {
 
         try {
             // Build payload — only getting_started fields that differ from defaults
-            const payload = {};
+            let payload = {};
             for (const f of this.schema) {
                 if (f.level !== "getting_started") {
                     continue;
@@ -821,6 +821,21 @@ class SetupWizard {
                 if (val !== undefined) {
                     payload[f.key] = val;
                 }
+            }
+
+            const pvSource = payload["pv_forecast_source.source"] ?? this.values["pv_forecast_source.source"];
+            const locationBasedSources = ["akkudoktor", "openmeteo", "openmeteo_local", "forecast_solar"];
+            if (locationBasedSources.includes(pvSource)) {
+                const transformed = {};
+                for (const [key, value] of Object.entries(payload)) {
+                    const templateMatch = key.match(/^pv_forecast\.([^\.]+)$/);
+                    if (templateMatch) {
+                        transformed[`pv_forecast.0.${templateMatch[1]}`] = value;
+                    } else {
+                        transformed[key] = value;
+                    }
+                }
+                payload = transformed;
             }
 
             // Save config

--- a/tests/config_web/test_api.py
+++ b/tests/config_web/test_api.py
@@ -519,6 +519,7 @@ def fresh_client(tmp_path):
     store.open()
 
     config = _sample_config()
+    config["pv_forecast"] = []
     module = _FakeModule(config, store, schema)
     init_api(store, schema, module)
     app.register_blueprint(config_bp)
@@ -548,6 +549,83 @@ class TestWizardAPI:
         data = resp.get_json()
         assert data["pending"] is False
         assert data["migrated"] is True
+
+    def test_save_location_based_pv_installation_succeeds(self, fresh_client):
+        """Saving a location-based PV source with an indexed pv_forecast entry should succeed."""
+        payload = {
+            "pv_forecast_source.source": "openmeteo",
+            "pv_forecast.0.name": "Roof",
+            "pv_forecast.0.lat": 48.0,
+            "pv_forecast.0.lon": 9.0,
+            "pv_forecast.0.azimuth": 90,
+            "pv_forecast.0.tilt": 30,
+            "pv_forecast.0.power": 4600,
+            "pv_forecast.0.powerInverter": 5000,
+            "pv_forecast.0.inverterEfficiency": 0.9,
+            "pv_forecast.0.horizon": "10",
+        }
+
+        resp = fresh_client.put(
+            "/api/config/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "pv_forecast.0.name" in data["updated"]
+
+        resp2 = fresh_client.get("/api/config/")
+        merged = resp2.get_json()
+        assert isinstance(merged["pv_forecast"], list)
+        assert len(merged["pv_forecast"]) == 1
+        assert merged["pv_forecast"][0]["name"] == "Roof"
+
+    def test_save_location_based_source_without_installations_blocks(self, fresh_client):
+        """Saving a location-based source without PV installations should return unmet dependencies."""
+        resp = fresh_client.put(
+            "/api/config/",
+            data=json.dumps({"pv_forecast_source.source": "openmeteo"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is False
+        assert data["unmet_dependencies"]
+        assert any(dep["field"] == "pv_forecast" for dep in data["unmet_dependencies"])
+
+    def test_save_pv_installation_after_location_source_succeeds(self, fresh_client):
+        """After saving a location-based source, adding a pv_forecast entry later should succeed."""
+        resp1 = fresh_client.put(
+            "/api/config/",
+            data=json.dumps({"pv_forecast_source.source": "openmeteo"}),
+            content_type="application/json",
+        )
+        assert resp1.status_code == 200
+        assert resp1.get_json()["success"] is False
+
+        resp2 = fresh_client.put(
+            "/api/config/",
+            data=json.dumps({
+                "pv_forecast.0.name": "Roof",
+                "pv_forecast.0.lat": 48.0,
+                "pv_forecast.0.lon": 9.0,
+                "pv_forecast.0.azimuth": 90,
+                "pv_forecast.0.tilt": 30,
+                "pv_forecast.0.power": 4600,
+                "pv_forecast.0.powerInverter": 5000,
+                "pv_forecast.0.inverterEfficiency": 0.9,
+                "pv_forecast.0.horizon": "10",
+            }),
+            content_type="application/json",
+        )
+        assert resp2.status_code == 200
+        assert resp2.get_json()["success"] is True
+
+        resp3 = fresh_client.get("/api/config/")
+        merged = resp3.get_json()
+        assert len(merged["pv_forecast"]) == 1
+        assert merged["pv_forecast"][0]["name"] == "Roof"
 
     def test_wizard_complete_marks_done(self, fresh_client):
         """POST /api/config/wizard-complete should mark wizard as completed."""

--- a/tests/config_web/test_merger.py
+++ b/tests/config_web/test_merger.py
@@ -1,5 +1,9 @@
+# pylint: disable=redefined-outer-name
 """
 Unit tests for the merged config builder.
+
+Note: redefined-outer-name is disabled because pytest fixtures with the same
+names are a standard pattern for parameterized and scoped test fixtures.
 """
 
 import pytest
@@ -294,8 +298,8 @@ class TestMergedConfigBuilder:
         merged = build_merged_config(config, store, schema)
 
         # Verify injected empty values
-        assert merged["inverter"]["url"] == ""
-        assert merged["inverter"]["token"] == ""
+        assert not merged["inverter"]["url"]
+        assert not merged["inverter"]["token"]
 
     def test_ssl_ignore_propagates_to_load(self, store, schema):
         """ssl_ignore from data_source should propagate to load section."""
@@ -368,7 +372,10 @@ class TestMergedConfigBuilder:
         merged = build_merged_config(config, store, schema)
 
         # Verify URL and token are constructed from central HA
-        assert merged["price"]["data_url"] == "http://homeassistant.local:8123/api/states/sensor.electricity_prices"
+        expected_url = (
+            "http://homeassistant.local:8123/api/states/sensor.electricity_prices"
+        )
+        assert merged["price"]["data_url"] == expected_url
         assert merged["price"]["data_token"] == "ha_token_123"
 
     def test_central_ha_pv_timeseries(self, store, schema):
@@ -387,7 +394,10 @@ class TestMergedConfigBuilder:
         merged = build_merged_config(config, store, schema)
 
         # Verify URL and token are constructed from central HA
-        assert merged["pv_forecast_source"]["data_url"] == "http://homeassistant.local:8123/api/states/sensor.pv_forecast_data"
+        expected_pv_url = (
+            "http://homeassistant.local:8123/api/states/sensor.pv_forecast_data"
+        )
+        assert merged["pv_forecast_source"]["data_url"] == expected_pv_url
         assert merged["pv_forecast_source"]["data_token"] == "ha_token_456"
 
     def test_manual_url_used_when_central_ha_disabled(self, store, schema):

--- a/tests/config_web/test_merger.py
+++ b/tests/config_web/test_merger.py
@@ -159,6 +159,64 @@ class TestMergedConfigBuilder:
         assert len(merged["pv_forecast"]) == 1
         assert merged["pv_forecast"][0]["name"] == "Roof"
 
+    def test_pv_forecast_from_indexed_keys(self, store, schema):
+        """Indexed pv_forecast keys should rebuild a list entry."""
+        config = _sample_config()
+        migrate_yaml_to_store(config, store, schema)
+
+        store.set("pv_forecast.0.name", "Roof")
+        store.set("pv_forecast.0.lat", 48.0)
+        store.set("pv_forecast.0.lon", 9.0)
+        store.set("pv_forecast.0.azimuth", 90)
+        store.set("pv_forecast.0.tilt", 30)
+        store.set("pv_forecast.0.power", 4600)
+        store.set("pv_forecast.0.powerInverter", 5000)
+        store.set("pv_forecast.0.inverterEfficiency", 0.9)
+        store.set("pv_forecast.0.horizon", "10")
+
+        merged = build_merged_config(config, store, schema)
+        assert len(merged["pv_forecast"]) == 1
+        assert merged["pv_forecast"][0]["name"] == "Roof"
+        assert merged["pv_forecast"][0]["lat"] == 48.0
+
+    def test_pv_forecast_from_unindexed_template_keys_synthesizes_entry(self, store, schema):
+        """Unindexed pv_forecast template keys should synthesize one installation entry."""
+        config = _sample_config()
+        config["pv_forecast"] = []
+
+        store.set("pv_forecast.name", "TemplateRoof")
+        store.set("pv_forecast.lat", 48.0)
+        store.set("pv_forecast.lon", 9.0)
+        store.set("pv_forecast.azimuth", 90)
+        store.set("pv_forecast.tilt", 30)
+        store.set("pv_forecast.power", 4600)
+
+        merged = build_merged_config(config, store, schema)
+        assert len(merged["pv_forecast"]) == 1
+        assert merged["pv_forecast"][0]["name"] == "TemplateRoof"
+        assert merged["pv_forecast"][0]["powerInverter"] == 5000
+        assert merged["pv_forecast"][0]["inverterEfficiency"] == 0.9
+
+    def test_pv_forecast_indexed_takes_precedence_over_template_keys(self, store, schema):
+        """Indexed pv_forecast keys should win over template keys when both exist."""
+        config = _sample_config()
+        migrate_yaml_to_store(config, store, schema)
+
+        store.set("pv_forecast.name", "TemplateRoof")
+        store.set("pv_forecast.0.name", "IndexedRoof")
+        store.set("pv_forecast.0.lat", 48.0)
+        store.set("pv_forecast.0.lon", 9.0)
+        store.set("pv_forecast.0.azimuth", 90)
+        store.set("pv_forecast.0.tilt", 30)
+        store.set("pv_forecast.0.power", 4600)
+        store.set("pv_forecast.0.powerInverter", 5000)
+        store.set("pv_forecast.0.inverterEfficiency", 0.9)
+        store.set("pv_forecast.0.horizon", "10")
+
+        merged = build_merged_config(config, store, schema)
+        assert len(merged["pv_forecast"]) == 1
+        assert merged["pv_forecast"][0]["name"] == "IndexedRoof"
+
     def test_data_source_inherits_to_load(self, store, schema):
         """If load.source is 'default', data_source should populate it."""
         config = _sample_config()

--- a/tests/interfaces/optimization_backends/test_optimization_backend_local_evopt.py
+++ b/tests/interfaces/optimization_backends/test_optimization_backend_local_evopt.py
@@ -19,6 +19,7 @@ Usage:
 # pylint: disable=protected-access
 
 import pytest
+import pulp
 import pytz
 from datetime import datetime as _real_datetime
 from unittest.mock import patch
@@ -30,6 +31,7 @@ from src.interfaces.optimization_backends.local_evopt.optimizer import (
     OptimizationStrategy,
     Optimizer,
     TimeSeriesData,
+    _resolve_cbc_solver,
 )
 
 
@@ -591,6 +593,65 @@ class TestOptimizerSettings:
 # ---------------------------------------------------------------------------
 # 9. OptimizationInterface backend selection
 # ---------------------------------------------------------------------------
+
+class TestCbcSolverSelection:
+    """Test auto-detection of system vs bundled CBC solver."""
+
+    def test_uses_system_binary_when_available(self):
+        """Prefer a system-installed CBC executable when present on PATH."""
+        with patch(
+            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
+            return_value="/usr/bin/cbc",
+        ):
+            solver = _resolve_cbc_solver(
+                msg=0,
+                num_threads=2,
+                time_limit=30.0,
+                gapRel=0.01,
+            )
+
+        # A system path uses COIN_CMD (PULP_CBC_CMD rejects custom paths).
+        assert isinstance(solver, pulp.COIN_CMD)
+        assert solver.path == "/usr/bin/cbc"
+        assert solver.msg == 0
+        assert solver.optionsDict.get("threads") == 2
+        assert solver.timeLimit == 30.0
+        assert solver.optionsDict.get("gapRel") == 0.01
+
+    def test_falls_back_to_bundled_binary_when_no_system_cbc(self):
+        """Fall back to the PuLP bundled CBC when no system binary is found."""
+        with patch(
+            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
+            return_value=None,
+        ):
+            solver = _resolve_cbc_solver(
+                msg=0,
+                num_threads=4,
+                time_limit=120.0,
+                gapRel=0.05,
+            )
+
+        assert isinstance(solver, pulp.PULP_CBC_CMD)
+        # The bundled default uses pulp's internal default path; the important
+        # thing is that we did NOT pass a system path in.
+        assert solver.path != "/usr/bin/cbc"
+        assert solver.optionsDict.get("threads") == 4
+        assert solver.timeLimit == 120.0
+        assert solver.optionsDict.get("gapRel") == 0.05
+
+    def test_default_settings_forwarded(self):
+        """Default OptimizerSettings values are forwarded to the solver."""
+        with patch(
+            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
+            return_value="/usr/bin/cbc",
+        ):
+            solver = _resolve_cbc_solver(msg=1)
+
+        assert solver.msg == 1
+        assert solver.optionsDict.get("threads") is None
+        assert solver.timeLimit is None
+        assert solver.optionsDict.get("gapRel") is None
+
 
 class TestOptimizationInterfaceSelection:
     """Test OptimizationInterface backend selection for local_evopt."""

--- a/tests/interfaces/optimization_backends/test_optimization_backend_local_evopt.py
+++ b/tests/interfaces/optimization_backends/test_optimization_backend_local_evopt.py
@@ -18,21 +18,41 @@ Usage:
 
 # pylint: disable=protected-access
 
+import subprocess
+from datetime import datetime as _real_datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 import pulp
 import pytz
-from datetime import datetime as _real_datetime
-from unittest.mock import patch
 
 from src.interfaces.optimization_backends.optimization_backend_local_evopt import LocalEVOptBackend
+from src.interfaces.optimization_backends.local_evopt import optimizer as _optimizer_mod
 from src.interfaces.optimization_backends.local_evopt.optimizer import (
     BatteryConfig,
+    CbcSolverUnavailableError,
     GridConfig,
     OptimizationStrategy,
     Optimizer,
     TimeSeriesData,
+    _cbc_runs,
     _resolve_cbc_solver,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cbc_probe_cache():
+    """
+    Reset the module-level CBC probe cache around every test.
+
+    The probe result is cached for the process lifetime, so without this a
+    mocked selection would leak into the tests further down this file that
+    perform real solves.
+    """
+    _optimizer_mod._resolved_cbc = None
+    yield
+    _optimizer_mod._resolved_cbc = None
 
 
 # ---------------------------------------------------------------------------
@@ -594,15 +614,17 @@ class TestOptimizerSettings:
 # 9. OptimizationInterface backend selection
 # ---------------------------------------------------------------------------
 
+_OPT = "src.interfaces.optimization_backends.local_evopt.optimizer"
+_BUNDLED_CBC = pulp.PULP_CBC_CMD.pulp_cbc_path
+
+
 class TestCbcSolverSelection:
     """Test auto-detection of system vs bundled CBC solver."""
 
     def test_uses_system_binary_when_available(self):
         """Prefer a system-installed CBC executable when present on PATH."""
-        with patch(
-            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
-            return_value="/usr/bin/cbc",
-        ):
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", return_value=None):
             solver = _resolve_cbc_solver(
                 msg=0,
                 num_threads=2,
@@ -610,7 +632,8 @@ class TestCbcSolverSelection:
                 gapRel=0.01,
             )
 
-        # A system path uses COIN_CMD (PULP_CBC_CMD rejects custom paths).
+        # Both candidates use COIN_CMD: PULP_CBC_CMD rejects custom paths, and
+        # COIN_CMD is its base class with an identical solve path.
         assert isinstance(solver, pulp.COIN_CMD)
         assert solver.path == "/usr/bin/cbc"
         assert solver.msg == 0
@@ -620,10 +643,8 @@ class TestCbcSolverSelection:
 
     def test_falls_back_to_bundled_binary_when_no_system_cbc(self):
         """Fall back to the PuLP bundled CBC when no system binary is found."""
-        with patch(
-            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
-            return_value=None,
-        ):
+        with patch(f"{_OPT}.shutil.which", return_value=None), \
+             patch(f"{_OPT}._cbc_runs", return_value=None):
             solver = _resolve_cbc_solver(
                 msg=0,
                 num_threads=4,
@@ -631,26 +652,128 @@ class TestCbcSolverSelection:
                 gapRel=0.05,
             )
 
-        assert isinstance(solver, pulp.PULP_CBC_CMD)
-        # The bundled default uses pulp's internal default path; the important
-        # thing is that we did NOT pass a system path in.
-        assert solver.path != "/usr/bin/cbc"
+        assert isinstance(solver, pulp.COIN_CMD)
+        assert solver.path == _BUNDLED_CBC
         assert solver.optionsDict.get("threads") == 4
         assert solver.timeLimit == 120.0
         assert solver.optionsDict.get("gapRel") == 0.05
 
+    def test_broken_system_cbc_does_not_shadow_bundled(self):
+        """
+        A system cbc that cannot be executed must not win over a working
+        bundled binary. Regression guard: the previous implementation trusted
+        shutil.which() without ever running the candidate.
+        """
+        def _probe(path):
+            return "boom: cannot exec" if path == "/usr/bin/cbc" else None
+
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", side_effect=_probe):
+            solver = _resolve_cbc_solver(msg=0)
+
+        assert solver.path == _BUNDLED_CBC
+
+    def test_raises_when_no_cbc_can_run(self):
+        """
+        When neither candidate executes — the Alpine/musl x86_64 case — raise an
+        actionable error instead of leaking a bare FileNotFoundError from the
+        solve (issues #260, #264, #265, #273).
+        """
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", return_value="missing ELF interpreter"):
+            with pytest.raises(CbcSolverUnavailableError) as excinfo:
+                _resolve_cbc_solver(msg=0)
+
+        message = str(excinfo.value)
+        assert "missing ELF interpreter" in message
+        assert "system CBC" in message
+        assert "bundled CBC" in message
+        # Must tell the user what to actually do about it.
+        assert "add-on" in message
+
+    def test_probe_result_is_cached(self):
+        """The probe forks a subprocess, so it must run once per process."""
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", return_value=None) as probe:
+            _resolve_cbc_solver(msg=0)
+            _resolve_cbc_solver(msg=0)
+            _resolve_cbc_solver(msg=0)
+
+        assert probe.call_count == 1
+
     def test_default_settings_forwarded(self):
         """Default OptimizerSettings values are forwarded to the solver."""
-        with patch(
-            "src.interfaces.optimization_backends.local_evopt.optimizer.shutil.which",
-            return_value="/usr/bin/cbc",
-        ):
+        with patch(f"{_OPT}.shutil.which", return_value="/usr/bin/cbc"), \
+             patch(f"{_OPT}._cbc_runs", return_value=None):
             solver = _resolve_cbc_solver(msg=1)
 
         assert solver.msg == 1
         assert solver.optionsDict.get("threads") is None
         assert solver.timeLimit is None
         assert solver.optionsDict.get("gapRel") is None
+
+
+class TestCbcProbe:
+    """Test _cbc_runs() rejection reasons — no real subprocess is spawned."""
+
+    def test_accepts_clean_exit(self):
+        """A candidate that runs and exits 0 is accepted."""
+        with patch(f"{_OPT}.subprocess.run", return_value=SimpleNamespace(returncode=0)):
+            assert _cbc_runs("/usr/bin/cbc") is None
+
+    def test_missing_elf_interpreter(self):
+        """The Alpine/musl case: the file exists but execve returns ENOENT."""
+        with patch(f"{_OPT}.subprocess.run", side_effect=FileNotFoundError()):
+            reason = _cbc_runs("/opt/venv/.../solverdir/cbc/linux/i64/cbc")
+
+        assert reason is not None
+        assert "ELF interpreter" in reason
+        assert "musl" in reason
+
+    def test_illegal_instruction(self):
+        """A binary needing CPU features the host lacks (Proxmox kvm64)."""
+        with patch(f"{_OPT}.subprocess.run", return_value=SimpleNamespace(returncode=-4)):
+            reason = _cbc_runs("/usr/bin/cbc")
+
+        assert reason is not None
+        assert "signal 4" in reason
+        assert "illegal instruction" in reason
+
+    def test_nonzero_exit(self):
+        """A candidate that runs but reports failure is rejected."""
+        with patch(f"{_OPT}.subprocess.run", return_value=SimpleNamespace(returncode=1)):
+            reason = _cbc_runs("/usr/bin/cbc")
+
+        assert reason is not None
+        assert "status 1" in reason
+
+    def test_timeout(self):
+        """A candidate that hangs is rejected rather than blocking the solve."""
+        with patch(
+            f"{_OPT}.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="cbc", timeout=15.0),
+        ):
+            reason = _cbc_runs("/usr/bin/cbc")
+
+        assert reason is not None
+        assert "15s" in reason
+
+    def test_other_oserror(self):
+        """Any other OSError (e.g. permissions) is reported, not raised."""
+        with patch(f"{_OPT}.subprocess.run", side_effect=PermissionError("denied")):
+            reason = _cbc_runs("/usr/bin/cbc")
+
+        assert reason is not None
+        assert "could not be started" in reason
+
+    def test_real_bundled_binary_probe(self):
+        """
+        Sanity check against the actual installed pulp binary. On glibc CI this
+        proves the probe accepts a genuinely working CBC rather than only
+        agreeing with mocks.
+        """
+        reason = _cbc_runs(_BUNDLED_CBC)
+        assert reason is None, f"bundled CBC unexpectedly rejected: {reason}"
 
 
 class TestOptimizationInterfaceSelection:

--- a/tests/interfaces/test_pv_interface.py
+++ b/tests/interfaces/test_pv_interface.py
@@ -1322,6 +1322,29 @@ def test_victron_dispatch_routing(monkeypatch):
 # evcc tests
 # ---------------------------------------------------------------------------
 
+def test_evcc_compact_unix_timestamp_forecast_is_supported(monkeypatch):
+    """Support EVCC #32391 compact [unix_timestamp, power] entries."""
+    config_entry = {"name": "evcc_test", "lat": 50, "lon": 8, "power": 100}
+    config_source = {"source": "evcc", "use_real_data_correction": False}
+    base = real_datetime.datetime.now(real_datetime.timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    compact_timeseries = [
+        [int((base + real_datetime.timedelta(minutes=15 * i)).timestamp()), 40.0]
+        for i in range(192)
+    ]
+
+    def mock_retry_request(request_func, error_handler, **kwargs):
+        return compact_timeseries, "1.0"
+
+    monkeypatch.setattr(PvInterface, "_retry_request", staticmethod(mock_retry_request))
+    pv = PvInterface(config_source, [config_entry], 900, {"url": "http://dummy-evcc"}, timezone="UTC")
+
+    result = pv._PvInterface__get_pv_forecast_evcc_api(config_entry, hours=48)
+
+    assert len(result) == 192
+    assert result == [10.0] * 192
+
 def test_evcc_scaling_enabled_applies_scale_factor(monkeypatch):
 
     def test_evcc_scaling_disabled_uses_1(monkeypatch):

--- a/tests/interfaces/test_pv_interface_two_tier_validation.py
+++ b/tests/interfaces/test_pv_interface_two_tier_validation.py
@@ -1,39 +1,41 @@
-# pylint: disable=protected-access
+# pylint: disable=protected-access,redefined-outer-name
 """
 Unit tests for PvInterface two-tier validation system (Issue #259).
 
 Tests for graceful degradation at startup (lenient mode) vs strict validation
 at runtime/hot-reload. Ensures addon doesn't crash when config is incomplete,
 allowing users to access web UI to fix configuration.
+
+Note: redefined-outer-name is disabled because pytest fixtures with the same
+names are a standard pattern for parameterized and scoped test fixtures.
 """
+
+import logging
 
 import pytest
 from src.interfaces.pv_interface import PvInterface
 
-time_frame_base = 3600
+TIME_FRAME_BASE = 3600
 
 
 @pytest.fixture(autouse=True)
 def patch_thread(monkeypatch):
-    """
-    Fixture to patch threading.Thread to avoid starting real threads during tests.
-    """
-
+    """Patch threading.Thread to avoid starting real threads during tests."""
     class DummyThread:
         """A dummy thread class used for testing purposes."""
 
         def __init__(self, *args, **kwargs):
-            pass
+            """Initialize a dummy thread (no-op)."""
 
         def start(self):
-            pass
+            """Start the dummy thread (no-op)."""
 
         def is_alive(self):
             """Return False so shutdown() doesn't wait for thread."""
             return False
 
         def join(self):
-            pass
+            """Join the dummy thread (no-op)."""
 
     monkeypatch.setattr("threading.Thread", DummyThread)
 
@@ -120,7 +122,7 @@ class TestStartupValidationGracefulDegradation:
 
         # Should not raise SystemExit
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         assert pv.configuration_state == "incomplete"
@@ -133,7 +135,7 @@ class TestStartupValidationGracefulDegradation:
         config_source, config = incomplete_victron_no_api_key
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         assert pv.configuration_state == "incomplete"
@@ -146,7 +148,7 @@ class TestStartupValidationGracefulDegradation:
         config_source, config = incomplete_solcast_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         assert pv.configuration_state == "incomplete"
@@ -159,7 +161,7 @@ class TestStartupValidationGracefulDegradation:
         config_source, config = incomplete_solcast_no_resource_id
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         assert pv.configuration_state == "incomplete"
@@ -174,7 +176,7 @@ class TestStartupValidationGracefulDegradation:
         config_source, config = empty_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # Empty config -> incomplete state (not yet configured)
@@ -191,7 +193,7 @@ class TestStartupValidationGracefulDegradation:
         config = {"name": "System", "lat": 51.5, "lon": 10.0}  # Dict, not list!
 
         # Should NOT crash with sys.exit, but should start in degraded mode
-        pv = PvInterface(config_source, config, time_frame_base, {}, timezone="UTC")
+        pv = PvInterface(config_source, config, TIME_FRAME_BASE, {}, timezone="UTC")
 
         # Structural errors result in incomplete/degraded mode
         assert pv.configuration_state == "incomplete"
@@ -202,7 +204,7 @@ class TestStartupValidationGracefulDegradation:
         config_source, config = valid_victron_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         assert pv.configuration_state == "valid"
@@ -223,7 +225,7 @@ class TestConfigurationStateTracking:
         config = []
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # After initialization, state should be set (either incomplete or valid)
@@ -236,7 +238,7 @@ class TestConfigurationStateTracking:
         config_source, config = incomplete_victron_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         assert pv.configuration_state == "incomplete"
@@ -246,7 +248,7 @@ class TestConfigurationStateTracking:
         config_source, config = valid_victron_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         assert pv.configuration_state == "valid"
@@ -256,7 +258,7 @@ class TestConfigurationStateTracking:
         config_source, config = valid_victron_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         if pv.configuration_state == "valid":
@@ -280,7 +282,7 @@ class TestConfigurationStateTracking:
         }]
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         assert pv.configuration_state == "valid"
@@ -289,7 +291,7 @@ class TestConfigurationStateTracking:
 
 # ============================================================================
 # TEST SUITE 3: get_summarized_pv_forecast() Guard for Incomplete Config
-# ============================================================================
+# ============================================================================  # pylint: disable=line-too-long
 
 
 class TestGetSummarizedPvForecastGuard:
@@ -305,7 +307,7 @@ class TestGetSummarizedPvForecastGuard:
         config_source, config = incomplete_victron_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # Should return zeros, not crash
@@ -314,7 +316,7 @@ class TestGetSummarizedPvForecastGuard:
         # Should be array of zeros (48 elements)
         assert isinstance(forecast, list)
         assert len(forecast) == 48
-        assert all(v == 0.0 for v in forecast)
+        assert all(not v for v in forecast)
 
     def test_get_forecast_with_incomplete_config_does_not_crash(
         self, incomplete_solcast_config
@@ -323,14 +325,14 @@ class TestGetSummarizedPvForecastGuard:
         config_source, config = incomplete_solcast_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # Should not raise any exception
         try:
             forecast = pv.get_summarized_pv_forecast()
             assert isinstance(forecast, list)
-        except Exception as exc:
+        except ValueError as exc:
             pytest.fail(f"get_summarized_pv_forecast() should not crash: {exc}")
 
     def test_get_forecast_logs_configuration_state_when_incomplete(
@@ -342,11 +344,11 @@ class TestGetSummarizedPvForecastGuard:
         config_source, config = incomplete_victron_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         with caplog.at_level("DEBUG"):
-            forecast = pv.get_summarized_pv_forecast()
+            _ = pv.get_summarized_pv_forecast()
 
         # Should log skipping forecast retrieval
         assert any("Skipping PV forecast retrieval" in record.message for record in caplog.records)
@@ -372,7 +374,7 @@ class TestHotReloadValidationStrict:
 
         # Start with valid config
         pv = PvInterface(
-            config_source_valid, config_valid, time_frame_base, {}, timezone="UTC"
+            config_source_valid, config_valid, TIME_FRAME_BASE, {}, timezone="UTC"
         )
         assert pv.configuration_state == "valid"
         assert pv.configuration_valid is True
@@ -402,7 +404,7 @@ class TestHotReloadValidationStrict:
 
         # Start with incomplete config
         pv = PvInterface(
-            config_source_incomplete, config_incomplete, time_frame_base, {}, timezone="UTC"
+            config_source_incomplete, config_incomplete, TIME_FRAME_BASE, {}, timezone="UTC"
         )
         assert pv.configuration_state == "incomplete"
         assert pv.configuration_valid is False
@@ -428,7 +430,7 @@ class TestHotReloadValidationStrict:
         config_source, config = valid_victron_config
 
         pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # Access the internal old_state dict during reload by catching the exception
@@ -465,7 +467,7 @@ class TestValidationModeParameter:
         config_copy = [c.copy() for c in config]
 
         pv = PvInterface(
-            {"source": "akkudoktor"}, [], time_frame_base, {}, timezone="UTC"
+            {"source": "akkudoktor"}, [], TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # Manually set config and call check_config with strict=True
@@ -487,7 +489,7 @@ class TestValidationModeParameter:
         config_copy = [c.copy() for c in config]
 
         pv = PvInterface(
-            {"source": "akkudoktor"}, [], time_frame_base, {}, timezone="UTC"
+            {"source": "akkudoktor"}, [], TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # Manually set config and call check_config with strict=False
@@ -515,11 +517,10 @@ class TestLoggingBehavior:
         """
         config_source, config = incomplete_victron_config
 
-        import logging
         caplog.set_level(logging.WARNING)
 
-        pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+        _ = PvInterface(
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # Should have warnings in logs
@@ -535,11 +536,10 @@ class TestLoggingBehavior:
         """
         config_source, config = incomplete_victron_config
 
-        import logging
         caplog.set_level(logging.WARNING)
 
-        pv = PvInterface(
-            config_source, config, time_frame_base, {}, timezone="UTC"
+        _ = PvInterface(
+            config_source, config, TIME_FRAME_BASE, {}, timezone="UTC"
         )
 
         # Should mention web UI or Settings

--- a/tests/interfaces/test_pv_interface_two_tier_validation.py
+++ b/tests/interfaces/test_pv_interface_two_tier_validation.py
@@ -264,6 +264,28 @@ class TestConfigurationStateTracking:
         else:
             assert pv.configuration_valid is False
 
+    def test_startup_location_based_source_with_one_installation_is_valid(self):
+        """A location-based source with one complete installation should start valid."""
+        config_source = {"source": "akkudoktor"}
+        config = [{
+            "name": "Roof",
+            "lat": 48.0,
+            "lon": 9.0,
+            "azimuth": 90,
+            "tilt": 30,
+            "power": 4600,
+            "powerInverter": 5000,
+            "inverterEfficiency": 0.9,
+            "horizon": "10",
+        }]
+
+        pv = PvInterface(
+            config_source, config, time_frame_base, {}, timezone="UTC"
+        )
+
+        assert pv.configuration_state == "valid"
+        assert pv.configuration_valid is True
+
 
 # ============================================================================
 # TEST SUITE 3: get_summarized_pv_forecast() Guard for Incomplete Config


### PR DESCRIPTION
## Release v0.3.37 — CBC solver fixes, EVCC forecast support, PV config fix

Merges `develop` into `main` (13 commits, 23 files, +744/−86).

### Fixes
- **CBC solver on Alpine/musl** — prefer the system-installed CBC binary over the glibc-linked one bundled with PyPI `pulp`; probe/execute candidate binaries at startup with clear solver logging. Fixes #260, #264, #265, #273.
- **EVCC forecast format** — PV interface now accepts the compact wire format `[unix_ts, value]` (s and ms precision) in addition to legacy `{ts, val}`.
- **Location-based PV installations** — preserved when saving config and rebuilding the merged config; regression tests added. Fixes #274 (via #277).
- **Version comparison** — corrected handling logic, test assertions updated.

### Docs & housekeeping
- Expanded README/user-doc troubleshooting: CBC error diagnostics, Home Assistant OS add-on notes, Proxmox `kvm64` CPU limitation called out as a separate issue.
- `pulp` constrained to `>=2.7.0,<4`.
- Version badges bumped 0.3.36 → 0.3.37; `docker_develop.yml` prefix updated; `CLAUDE.md` added to `.gitignore`.

Includes merges of #277 and #278.