### PR TITLE
feat: add whole-install backup and restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test_config_ui.py
 *.db-shm
 src/data/pv_yield_history.csv
 CLAUDE.md
+TODO_pv_yield_backup.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ test_config_ui.py
 *.db-shm
 src/data/pv_yield_history.csv
 CLAUDE.md
-TODO_pv_yield_backup.md

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ EOS Connect fetches real-time and forecast data (solar, prices), runs the integr
 - **Dynamic PV Override:** Intelligent discharge prevention during high solar production or intermittent clouds. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#dyn-override)
 - **PV Auto-Scaling:** Learns from historical measured solar yield and automatically corrects PV forecasts with per-timeframe scale factors before optimization. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#pv-autoscaling)
 - **Smart Grid Limits (EVopt):** Grid import/export limits automatically default to your inverter capabilities when not explicitly configured, ensuring optimization respects your hardware. [Learn more →](https://ohAnd.github.io/EOS_connect/advanced/index.html#grid-limits)
+- **Backup & Restore:** One file holding your whole install — configuration plus the measured PV yield history the auto-scaler learns from, which is otherwise deleted on a rolling window. Restores preview before they apply, and an old backup's history can be shifted into the current window so scaling works from the first run. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#backup-restore)
 - **Robust Data Quality Handling:** Automatic detection and recovery from incomplete Home Assistant sensor data gaps. Forward-fill strategy ensures optimization always receives complete, valid input arrays. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#data-quality)
 
 ---
@@ -167,6 +168,13 @@ log_level: info             # Log level: debug, info, warning, error
 - Open `http://localhost:8081` and click the gear icon to access the configuration page
 - Changes marked as **"hot-reloadable"** (e.g., feed-in price, SOC limits) take effect immediately
 - Other changes require a restart (the UI shows which fields need restart)
+
+### Backup & Restore
+- **Menu → Backup & Restore** saves configuration *and* measured PV yield history to one file, and restores both
+- The measured history is not backed up anywhere else and is purged on a rolling window (7 days by default)
+- Restoring always previews first — including which settings it would remove — and nothing is written until you confirm
+- **The backup file contains your tokens and inverter password in plain text.** Store it accordingly
+- Full details: [Backup & Restore](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#backup-restore)
 ---
 
 ## Troubleshooting & Advanced Configuration

--- a/docs/advanced/index.html
+++ b/docs/advanced/index.html
@@ -58,6 +58,7 @@
                     <a href="#opt-request-response" class="toc-link toc-sub">→ Optimization Request/Response</a>
                     <a href="#feedin-pricing-details" class="toc-link toc-sub">→ Feed-In Pricing Details</a>
                     <a href="#pv-autoscaling-api" class="toc-link toc-sub">→ PV Auto-Scaling API</a>
+                    <a href="#backup-api" class="toc-link toc-sub">→ Backup &amp; Restore API</a>
                     <a href="#system-mode-ref" class="toc-link toc-sub">→ System Modes</a>
                     <a href="#logging-api" class="toc-link toc-sub">→ Logging API</a>
                     <a href="#mqtt" class="toc-link">MQTT Integration</a>
@@ -351,6 +352,178 @@
                         forecast — the same days the scale factors are derived from. Today is excluded from both and
                         reported separately in <code>todays_partial_data</code>.
                     </p>
+
+                    <p>
+                        <code>restored_hours</code> counts how many hours of the window came from a restored backup
+                        rather than this system's own meter, and each entry in <code>aggregated_history.days</code>
+                        carries an <code>origin</code> of <code>measured</code>, <code>imported</code> or
+                        <code>seeded</code>. A day counts as measured as soon as one of its hours was recorded
+                        locally. See <a href="#backup-api">Backup &amp; Restore API</a>.
+                    </p>
+
+                    <h3 id="backup-api">Backup &amp; Restore API</h3>
+                    <p>
+                        Endpoints behind <strong>Menu → Backup &amp; Restore</strong>, covering the whole install:
+                        the configuration and the measured PV yield history. The configuration-only pair
+                        (<code>GET /api/config/export</code>, <code>POST /api/config/import</code>) is unchanged and
+                        still writes the flat settings file earlier versions produced.
+                    </p>
+
+                    <div class="alert alert-warning">
+                        <i class="fas fa-triangle-exclamation"></i>
+                        <strong>A backup file contains secrets in plain text</strong> — Home Assistant access
+                        tokens, price API tokens and the inverter password. It is never masked, because a masked
+                        file could not restore. Store it the way you would store a password.
+                    </div>
+
+                    <h4>Endpoints</h4>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Endpoint</th>
+                                <th>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>GET /api/backup/info</code></td>
+                                <td>What a backup taken now would contain: setting count, yield row count, the
+                                    oldest and newest recorded hour, and the current retention window.</td>
+                            </tr>
+                            <tr>
+                                <td><code>GET /api/backup/export</code></td>
+                                <td>The backup file itself.</td>
+                            </tr>
+                            <tr>
+                                <td><code>POST /api/backup/import</code></td>
+                                <td>Restore a backup, or preview one with <code>dry_run=1</code>.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <h4>Query parameters</h4>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Parameter</th>
+                                <th>Values</th>
+                                <th>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>include</code></td>
+                                <td><code>settings</code>, <code>pv_yield_history</code></td>
+                                <td>Comma-separated datasets to act on. Omit for all; pass it empty for none.</td>
+                            </tr>
+                            <tr>
+                                <td><code>mode</code></td>
+                                <td><code>replace</code> (default), <code>merge</code></td>
+                                <td>Import only. <code>replace</code> makes the stored configuration match the file
+                                    exactly, removing settings the file does not contain. <code>merge</code> keeps
+                                    them.</td>
+                            </tr>
+                            <tr>
+                                <td><code>history_mode</code></td>
+                                <td><code>as_is</code> (default), <code>seed</code></td>
+                                <td>Import only. <code>seed</code> shifts the yield rows forward so the newest lands
+                                    on yesterday.</td>
+                            </tr>
+                            <tr>
+                                <td><code>dry_run</code></td>
+                                <td><code>1</code></td>
+                                <td>Import only. Report what would happen and write nothing.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <h4>File format</h4>
+                    <p>
+                        The file is <strong>flat</strong>: settings sit at the top level in dot notation, next to the
+                        metadata and the dataset keys. This is deliberate. An older build resolves every top-level
+                        key against its own schema and skips what it does not recognise, so a flat file still
+                        restores every setting that build knows — whereas a nested
+                        <code>{"settings": {…}}</code> envelope would restore nothing and report success.
+                    </p>
+                    <pre><code>{
+  "battery.capacity_wh": 20000,
+  "eos.port": 8503,
+  "_format": "eos-connect-backup",
+  "_version": 1,
+  "_exported_at": "2026-08-23T10:00:00+00:00",
+  "_datasets": ["settings", "pv_yield_history"],
+  "pv_yield_history": [
+    {"timestamp": "2026-08-19T06:00:00+00:00", "date": "2026-08-19", "hour": 8,
+     "timeframe_id": 2, "real_delta_kwh": 0.83, "forecast_kwh": 0.91,
+     "local_date": "2026-08-19", "local_hour": 8, "local_offset_minutes": 120,
+     "origin": null}
+  ]
+}</code></pre>
+                    <p>
+                        Exported rows omit <code>id</code>, <code>created_at</code> and
+                        <code>real_counter_kwh</code>. The first two are local database artifacts; the meter counter
+                        is excluded because the autoscaler seeds its baseline from the newest stored row on startup,
+                        and a reading from another install would make the first live collection record the difference
+                        between two unrelated meters as one hour of yield. Scale factors are computed from
+                        <code>real_delta_kwh</code> and <code>forecast_kwh</code> only, so nothing is lost.
+                    </p>
+
+                    <h4>Import response</h4>
+                    <pre><code>{
+  "dry_run": false,
+  "datasets": ["settings", "pv_yield_history"],
+  "mode": "replace",
+  "history_mode": "seed",
+  "format": "eos-connect-backup",
+  "version": 1,
+  "exported_at": "2026-08-23T10:00:00+00:00",
+  "settings": {
+    "imported": 124, "changed": 3, "removed": ["evcc.url"],
+    "skipped": 0, "invalid": [],
+    "restart_required": ["eos_connect_web_port"],
+    "hot_reloaded": ["price.feed_in_price"],
+    "warnings": []
+  },
+  "pv_yield_history": {
+    "available": true, "imported": 84, "skipped": 0,
+    "total": 96, "valid": 84,
+    "outside_retention": 0, "shift_days": 18,
+    "collisions": 2, "dropped_old": 10,
+    "age_days": 19, "seed_recommended": true,
+    "retention_days": 7, "origin": "seeded",
+    "newest_local_date": "2026-08-04", "oldest_local_date": "2026-07-29",
+    "invalid": []
+  }
+}</code></pre>
+                    <p>
+                        <code>removed</code> lists settings deleted by <code>replace</code>; <code>invalid</code>
+                        lists values the current schema rejects, which are skipped individually rather than failing
+                        the whole restore. <code>hot_reloaded</code> fields take effect immediately;
+                        <code>restart_required</code> fields need a restart. <code>warnings</code> carries unmet
+                        cross-field dependencies, which are reported but never block a restore.
+                    </p>
+                    <p>
+                        For the history: <code>collisions</code> counts rows that would have landed on an hour
+                        already stored — existing rows are never overwritten — and <code>dropped_old</code> counts
+                        rows still outside the retention window after shifting, which are not written because the
+                        next hourly collection would delete them anyway.
+                    </p>
+
+                    <h4>Examples</h4>
+                    <pre><code># Download a full backup
+curl -o backup.json http://localhost:8081/api/backup/export
+
+# Preview what restoring it would do — writes nothing
+curl -X POST -H "Content-Type: application/json" --data-binary @backup.json \
+  "http://localhost:8081/api/backup/import?dry_run=1"
+
+# Restore configuration only, keeping settings the file does not contain
+curl -X POST -H "Content-Type: application/json" --data-binary @backup.json \
+  "http://localhost:8081/api/backup/import?include=settings&amp;mode=merge"
+
+# Restore an old backup, shifting its history into the current window
+curl -X POST -H "Content-Type: application/json" --data-binary @backup.json \
+  "http://localhost:8081/api/backup/import?history_mode=seed"</code></pre>
 
                     <h4 id="field-reference">Response Field Reference</h4>
 

--- a/docs/user-guide/configuration.html
+++ b/docs/user-guide/configuration.html
@@ -72,6 +72,7 @@
                     <a href="#timing-controls" class="toc-link toc-sub">→ Timing Controls</a>
                     <a href="#time-slot-config" class="toc-link toc-sub">→ Time Slot Configuration</a>
                     <a href="#other" class="toc-link">Other Settings</a>
+                    <a href="#backup-restore" class="toc-link">Backup &amp; Restore</a>
                     <a href="#examples" class="toc-link">Config Examples</a>
                     <a href="#param-reference" class="toc-link">Parameter Reference</a>
                     <a href="#example-full" class="toc-link toc-sub">→ Full Config</a>
@@ -4360,6 +4361,136 @@ price:
                         <p>The combination of <code>refresh_time</code> and <code>time_frame</code> allows you to
                             control both how frequently the system updates and how detailed the optimization is.</p>
                     </div>
+                </div>
+
+                <!-- Backup & Restore Section -->
+                <div class="content-section" id="backup-restore">
+                    <h2><i class="fas fa-box-archive"></i> Backup &amp; Restore</h2>
+                    <p>
+                        <strong>Menu → Backup &amp; Restore</strong> saves and restores your whole install in one
+                        file: the configuration, and the measured PV yield history the auto-scaler learns from.
+                    </p>
+
+                    <div class="alert alert-warning">
+                        <h4><i class="fas fa-triangle-exclamation"></i> The backup file holds your passwords</h4>
+                        <p>
+                            It contains your Home Assistant access token, price API tokens and the inverter password
+                            in plain text. It has to — a file with those blanked out could not restore your system.
+                            Keep it wherever you keep passwords, and think twice before attaching it to a bug report
+                            or a forum post.
+                        </p>
+                    </div>
+
+                    <h3 id="backup-whats-included">What is in a backup</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Contents</th>
+                                <th>Why it matters</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><strong>Configuration</strong></td>
+                                <td>Every setting on this install, exactly as the configuration page shows them.</td>
+                            </tr>
+                            <tr>
+                                <td><strong>Measured PV yield history</strong></td>
+                                <td>The hourly record of what your panels actually produced against what was
+                                    forecast. This is what <a href="#pv-autoscaling">PV Auto-Scaling</a> derives its
+                                    scale factors from, and it is <strong>deleted on a rolling window</strong> — at
+                                    the default <code>retention_days</code> of 7, anything older than a week is gone
+                                    for good. Nothing else backs it up.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <p>
+                        You can tick either one on its own. The configuration page keeps its own small
+                        export/import buttons, and those stay <em>configuration only</em> — they do not touch the
+                        yield history.
+                    </p>
+
+                    <h3 id="backup-restoring">Restoring</h3>
+                    <p>
+                        Choosing a file never applies it straight away. EOS Connect first shows you what the restore
+                        would do — how many settings it would write, which ones it would remove, and what it would
+                        do with the history — and waits for you to confirm.
+                    </p>
+
+                    <h4>Configuration: replace or merge</h4>
+                    <ul>
+                        <li><strong>Replace</strong> (default) leaves your configuration exactly as the file has it.
+                            Settings the file does not contain are removed and fall back to their defaults. The
+                            preview lists them by name first.</li>
+                        <li><strong>Merge</strong> applies what the file contains and leaves everything else alone.</li>
+                    </ul>
+
+                    <div class="alert alert-info">
+                        <p>
+                            <i class="fas fa-circle-info"></i>
+                            <strong>Restoring a backup from an older version?</strong> Replace mode will remove
+                            settings that version did not have, and they will revert to their defaults. That is
+                            usually what you want after rolling back, but the preview lists exactly which settings
+                            are affected — read it before confirming, or use merge instead.
+                        </p>
+                    </div>
+
+                    <h4>PV history: original dates or shifted</h4>
+                    <p>
+                        A backup restored a few days after it was taken can go back at its original timestamps.
+                        An older one cannot usefully: anything beyond <code>retention_days</code> is deleted at the
+                        next hourly collection, so the auto-scaler would start from neutral factors and spend days
+                        re-learning your system.
+                    </p>
+                    <p>
+                        For that case EOS Connect offers to <strong>shift the history into the current window</strong>
+                        — whole days only, so every hour keeps its time of day and its timeframe. What the scale
+                        factors are actually made of is each hour's measured-to-forecast <em>ratio</em>, and that
+                        travels with the rows. You get working scale factors from the first optimization run instead
+                        of after a week of collection.
+                    </p>
+                    <ul>
+                        <li>Shifted rows are marked <strong>seeded</strong> and shown as such in the PV Auto-Scaling
+                            panel, so they are never mistaken for measurements from this system.</li>
+                        <li>They age out normally as real collection replaces them.</li>
+                        <li>An hour already recorded here is never overwritten by a shifted one.</li>
+                        <li>Shifting is only offered by default when the backup is older than your retention window.
+                            Inside it, shifted rows could land beside days this system already measured and count the
+                            same yield twice.</li>
+                    </ul>
+
+                    <div class="alert alert-info">
+                        <p>
+                            <i class="fas fa-circle-info"></i>
+                            The meter reading (<code>real_counter_kwh</code>) is deliberately not restored. It is an
+                            absolute counter, and a reading from another install or another meter would make the
+                            first live measurement record a nonsense value. The auto-scaler simply re-establishes its
+                            baseline on the first collection after a restore, costing one hour of measurement.
+                        </p>
+                    </div>
+
+                    <h3 id="backup-after-restore">After restoring</h3>
+                    <p>
+                        Settings that can be applied live are applied immediately — no restart needed. Settings that
+                        cannot raise the usual restart banner, and the restore summary says how many. Restart EOS
+                        Connect (or the add-on) to complete those.
+                    </p>
+
+                    <div class="alert alert-warning">
+                        <p>
+                            <i class="fas fa-triangle-exclamation"></i>
+                            If the restore reports hours <em>outside the retention window</em>, those rows will be
+                            deleted at the next hourly collection. Raise <code>retention_days</code> under
+                            <a href="#pv-autoscaling">PV Auto-Scaling</a> and restore again to keep them, or restore
+                            with shifting instead.
+                        </p>
+                    </div>
+
+                    <p>
+                        The REST endpoints behind this feature are documented under
+                        <a href="../advanced/index.html#backup-api">Backup &amp; Restore API</a>.
+                    </p>
                 </div>
 
                 <!-- Optimization Configuration Section -->

--- a/scripts/install_playwright_deps_userspace.sh
+++ b/scripts/install_playwright_deps_userspace.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Make Playwright's Chromium runnable without root.
+#
+# `playwright install-deps` needs sudo to apt-install Chromium's shared libraries.
+# Where that is not available, this fetches the same packages and unpacks them into
+# ~/.cache/ms-playwright-deps/lib, which tests/web/conftest.py adds to LD_LIBRARY_PATH
+# on its own. Nothing outside your home directory is touched.
+#
+# Usage:  scripts/install_playwright_deps_userspace.sh
+set -euo pipefail
+
+PREFIX="${HOME}/.cache/ms-playwright-deps"
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Chromium headless shell needs these beyond a base Ubuntu install. If a future build
+# reports another missing .so, add its package here — `ldd <chrome-binary>` names them.
+PACKAGES=(libnspr4 libnss3 libasound2t64)
+
+echo "Downloading: ${PACKAGES[*]}"
+( cd "${WORK}" && apt-get download "${PACKAGES[@]}" )
+
+echo "Unpacking into ${PREFIX}"
+mkdir -p "${PREFIX}/lib"
+for deb in "${WORK}"/*.deb; do
+    dpkg -x "${deb}" "${WORK}/root"
+done
+cp -r "${WORK}"/root/usr/lib/*/. "${PREFIX}/lib/"
+
+echo "Done. ${PREFIX}/lib now holds:"
+ls "${PREFIX}/lib" | sed 's/^/  /' | head -20
+echo
+echo "Now run:  pytest tests/web"

--- a/src/config_web/__init__.py
+++ b/src/config_web/__init__.py
@@ -220,6 +220,23 @@ class ConfigWebModule:
         if self._store:
             self._store.register_change_callback(callback)
 
+    def notify_config_changed(self, key, old_value, new_value):
+        """
+        Fire the hot-reload callbacks for a key that changed outside ``ConfigStore.set()``.
+
+        Bulk writes go through ``set_batch()``/``delete()``, which deliberately skip the
+        store's change callbacks so the whole import lands in one transaction.  The
+        importer replays the changes here afterwards, otherwise a restored config sits
+        in the database while the running interfaces keep their old values.
+        """
+        for cb in self._hot_reload_callbacks:
+            try:
+                cb(key, old_value, new_value)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "[ConfigWeb] Error in hot-reload callback for key '%s'", key
+                )
+
     # ------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------

--- a/src/config_web/__init__.py
+++ b/src/config_web/__init__.py
@@ -34,6 +34,7 @@ from .store import ConfigStore
 from .migration import migrate_yaml_to_store, migrate_ha_options_to_store
 from .merger import build_merged_config
 from .api import config_bp, init_api
+from .backup import backup_bp, init_backup
 
 try:  # running from src/ as a script — src/ is on sys.path
     from persistence import PvYieldStore
@@ -160,7 +161,9 @@ class ConfigWebModule:
         """
         self._flask_app = flask_app
         init_api(self._store, self._schema, self)
+        init_backup(self._store, self._schema, self)
         self._flask_app.register_blueprint(config_bp)
+        self._flask_app.register_blueprint(backup_bp)
         logger.info("[ConfigWeb] API registered on Flask app")
 
     def start(self):

--- a/src/config_web/api.py
+++ b/src/config_web/api.py
@@ -310,7 +310,8 @@ def _classify_settings(data: dict) -> tuple[dict, list[dict], int]:
         try:
             valid_data[key] = _coerce_value(field_def, value)
         except (TypeError, ValueError) as exc:
-            invalid.append({"key": key, "error": f"Invalid type: {exc}"})
+            logger.warning("[ConfigWeb] Rejected imported value for '%s': %s", key, exc)
+            invalid.append({"key": key, "error": _type_error_message(field_def)})
     return valid_data, invalid, skipped
 
 
@@ -790,10 +791,11 @@ def _validate_price_arrays(data: dict) -> list[dict]:
                             f"got {len(values)}"
                         )
                     })
-            except ValueError as e:
+            except ValueError as exc:
+                logger.debug("[ConfigWeb] fixed_24h_array is not parseable: %s", exc)
                 errors.append({
                     "key": "price.fixed_24h_array",
-                    "error": f"Array must contain numeric values: {e}"
+                    "error": "Array must contain numeric values only"
                 })
 
     return errors
@@ -842,8 +844,9 @@ def _validate_single(field_def, value) -> str:
     # Type coercion for comparison
     try:
         value = _coerce_value(field_def, value)
-    except (TypeError, ValueError) as e:
-        return f"Invalid type: {e}"
+    except (TypeError, ValueError) as exc:
+        logger.debug("[ConfigWeb] Value for '%s' will not coerce: %s", field_def.key, exc)
+        return _type_error_message(field_def)
 
     # Choices
     if "choices" in v:
@@ -868,6 +871,24 @@ def _validate_single(field_def, value) -> str:
         return "This field is required"
 
     return ""
+
+
+def _type_error_message(field_def) -> str:
+    """
+    A stable message for a value that will not coerce to the field's type.
+
+    Deliberately excludes the exception text.  ``int("abc")`` puts the offending value
+    into its own message, and interpolating that into an HTTP response is information
+    exposure through an exception — CodeQL flags it, and it reads as developer noise to
+    the person who has to act on it.  The detail is logged instead.
+    """
+    expected = {
+        "int": "a whole number",
+        "float": "a number",
+        "bool": "true or false",
+        "select": "one of the allowed choices",
+    }.get(field_def.field_type, f"a valid {field_def.field_type} value")
+    return f"Expected {expected}"
 
 
 def _coerce_value(field_def, value):

--- a/src/config_web/api.py
+++ b/src/config_web/api.py
@@ -18,6 +18,13 @@ logger = logging.getLogger("__main__")
 
 config_bp = Blueprint("config", __name__, url_prefix="/api/config")
 
+# Top-level keys a full backup file uses for non-setting data.  They sit alongside the
+# settings rather than in a nested envelope so that an older build, which resolves every
+# top-level key against the schema and skips what it does not know, still restores the
+# settings instead of silently importing nothing.  Listed here so the settings importer
+# can tell "not a setting" apart from "unknown key".
+_DATASET_KEYS = ("pv_yield_history",)
+
 # These are set by ConfigWebModule.start() before any request is served
 _store = None
 _schema = None
@@ -251,27 +258,165 @@ def export_config():
 
 @config_bp.route("/import", methods=["POST"])
 def import_config():
-    """Import a flat JSON dict of settings (from backup)."""
+    """Import a flat JSON dict of settings (from backup).
+
+    Config-scoped: any non-setting payload a full backup carries (e.g.
+    ``pv_yield_history``) is reported back but not restored here — that is what
+    ``/api/backup/import`` is for.
+    """
     data = flask_request.get_json(silent=True)
     if not data or not isinstance(data, dict):
         return jsonify({"error": "Request body must be a JSON object"}), 400
 
-    # Filter to known keys only, skip internal keys
+    result = apply_settings(data, mode="merge")
+    result["ignored_datasets"] = [k for k in _DATASET_KEYS if k in data]
+    return jsonify(result)
+
+
+def apply_settings(data: dict, mode: str = "merge") -> dict:
+    """
+    Write a flat dict of settings to the store the same way a normal save does.
+
+    ``ConfigStore.import_dict`` writes SQL directly, which skips validation, the
+    hot-reload callbacks and the restart-required bookkeeping that ``PUT /api/config/``
+    performs.  An import that bypasses those leaves the database updated while the
+    running interfaces keep their old values, with no restart banner to say so.  Both
+    import endpoints go through here instead.
+
+    Args:
+        data: Flat dot-notation key/value pairs.  Unknown and ``_``-prefixed keys are
+            ignored; a whole-backup payload can be passed unfiltered.
+        mode: ``"merge"`` keeps settings absent from *data*.  ``"replace"`` removes
+            them, so the stored config ends up matching the file exactly.
+
+    Returns:
+        Counts and per-key detail: ``imported``, ``removed``, ``skipped``, ``invalid``,
+        ``restart_required``, ``hot_reloaded``, ``warnings``.
+    """
+    before = _store.get_all()
+
+    # Validate before writing anything.  A single out-of-range value in an old backup
+    # must not abort the restore, so offenders are reported and skipped individually.
     valid_data = {}
+    invalid = []
     skipped = 0
     for key, value in data.items():
-        if key.startswith("_"):
-            skipped += 1
+        # Internal bookkeeping keys and file metadata are not settings, and are not
+        # "unknown keys" either — counting them as skipped makes re-importing your own
+        # export look like it lost something.
+        if key.startswith("_") or key in _DATASET_KEYS:
             continue
         field_def = _resolve_schema_key(key)
         if field_def is None:
             skipped += 1
             continue
-        valid_data[key] = _coerce_value(field_def, value)
+        err = _validate_single(field_def, value)
+        if err:
+            invalid.append({"key": key, "error": err})
+            continue
+        try:
+            valid_data[key] = _coerce_value(field_def, value)
+        except (TypeError, ValueError) as exc:
+            invalid.append({"key": key, "error": f"Invalid type: {exc}"})
 
-    count = _store.import_dict(valid_data) if valid_data else 0
+    removed = _remove_stale_keys(before, valid_data) if mode == "replace" else []
+
+    count = _store.set_batch(valid_data) if valid_data else 0
     _module.rebuild_config()
-    return jsonify({"imported": count, "skipped": skipped})
+
+    restart_required, hot_reloaded = _replay_changes(before, valid_data, removed)
+
+    # Persist restart-required fields so the banner survives a page reload, matching
+    # what update_config() does after a normal save.
+    if restart_required:
+        existing = _store.get("_restart_pending", []) or []
+        _store.set("_restart_pending", list(set(existing + restart_required)))
+
+    # Reported, never blocking: a restore is applied as a whole, and refusing it
+    # because one cross-field dependency is unmet would leave the user with nothing.
+    warnings = _check_dependencies(valid_data) if valid_data else []
+
+    logger.info(
+        "[ConfigWeb] Imported %d setting(s), removed %d, skipped %d, invalid %d (mode=%s)",
+        count,
+        len(removed),
+        skipped,
+        len(invalid),
+        mode,
+    )
+
+    return {
+        "imported": count,
+        "removed": removed,
+        "skipped": skipped,
+        "invalid": invalid,
+        "restart_required": restart_required,
+        "hot_reloaded": hot_reloaded,
+        "warnings": warnings,
+    }
+
+
+def _remove_stale_keys(before: dict, valid_data: dict) -> list[str]:
+    """
+    Delete stored settings that the imported file does not contain.
+
+    Only keys ``export_config()`` would have written are eligible, which makes replace
+    the exact inverse of export.  Two kinds of key are therefore left alone:
+
+    - ``_``-prefixed internals.  Wiping ``_wizard_completed`` would pop the setup
+      wizard after every restore, and ``_restart_pending`` carries the banner state.
+    - Keys with no schema definition, such as the raw ``pv_forecast`` list kept as a
+      migration fallback by the merger.  The indexed ``pv_forecast.0.*`` keys take
+      precedence over it, so it is inert rather than stale.
+    """
+    stale = [
+        key
+        for key in before
+        if not key.startswith("_")
+        and key not in valid_data
+        and _resolve_schema_key(key) is not None
+    ]
+    for key in stale:
+        _store.delete(key)
+    return stale
+
+
+def _replay_changes(
+    before: dict, valid_data: dict, removed: list[str]
+) -> tuple[list[str], list[str]]:
+    """
+    Fire hot-reload callbacks for everything the import actually changed.
+
+    ``set_batch()`` and ``delete()`` skip the store's own change callbacks so the write
+    stays a single transaction; without this replay the restored values would never
+    reach the running interfaces.  Returns the changed keys split into those needing a
+    restart and those applied live, classified exactly as ``update_config()`` does.
+    """
+    changes = [
+        (key, before.get(key), value)
+        for key, value in valid_data.items()
+        if key not in before or before[key] != value
+    ]
+    # A removed key falls back to its schema default, which is the value the interfaces
+    # now need to see.
+    for key in removed:
+        field_def = _resolve_schema_key(key)
+        changes.append((key, before.get(key), field_def.default if field_def else None))
+
+    restart_required = []
+    hot_reloaded = []
+    notify = getattr(_module, "notify_config_changed", None)
+    for key, old_value, new_value in changes:
+        field_def = _resolve_schema_key(key)
+        if field_def is not None:
+            if "restart_required" in field_def.labels:
+                restart_required.append(key)
+            elif field_def.hot_reload:
+                hot_reloaded.append(key)
+        if notify is not None:
+            notify(key, old_value, new_value)
+
+    return restart_required, hot_reloaded
 
 
 # ------------------------------------------------------------------

--- a/src/config_web/api.py
+++ b/src/config_web/api.py
@@ -241,19 +241,27 @@ def get_restart_required():
 # ------------------------------------------------------------------
 
 
+def export_settings_dict() -> dict:
+    """
+    Every stored setting worth writing to a backup file, flat and dot-notated.
+
+    Excludes internal keys (prefixed with ``_``) and raw array keys that are redundant
+    with their indexed children (the ``pv_forecast`` list is already present as
+    ``pv_forecast.0.azimuth`` and friends).  Shared with ``/api/backup`` so both files
+    carry exactly the same settings, and so replace mode can be the precise inverse of
+    what this writes.
+    """
+    return {
+        k: v
+        for k, v in _store.export_dict().items()
+        if not k.startswith("_") and _resolve_schema_key(k) is not None
+    }
+
+
 @config_bp.route("/export", methods=["GET"])
 def export_config():
     """Export current config as a flat JSON dict (for backup)."""
-    all_settings = _store.export_dict()
-    # Exclude internal keys (prefixed with _) and raw array keys that are
-    # redundant with their indexed children (e.g. "pv_forecast" array is
-    # already present as "pv_forecast.0.azimuth" etc.)
-    filtered = {
-        k: v
-        for k, v in all_settings.items()
-        if not k.startswith("_") and _resolve_schema_key(k) is not None
-    }
-    return jsonify(filtered)
+    return jsonify(export_settings_dict())
 
 
 @config_bp.route("/import", methods=["POST"])
@@ -271,6 +279,78 @@ def import_config():
     result = apply_settings(data, mode="merge")
     result["ignored_datasets"] = [k for k in _DATASET_KEYS if k in data]
     return jsonify(result)
+
+
+def _classify_settings(data: dict) -> tuple[dict, list[dict], int]:
+    """
+    Split an incoming payload into writable values, rejects and unknown keys.
+
+    A single out-of-range value in an old backup must not abort the restore, so
+    offenders are reported and skipped individually rather than failing the request.
+
+    Returns ``(valid_data, invalid, skipped)``.
+    """
+    valid_data = {}
+    invalid = []
+    skipped = 0
+    for key, value in data.items():
+        # Internal bookkeeping keys and file metadata are not settings, and are not
+        # "unknown keys" either — counting them as skipped makes re-importing your own
+        # export look like it lost something.
+        if key.startswith("_") or key in _DATASET_KEYS:
+            continue
+        field_def = _resolve_schema_key(key)
+        if field_def is None:
+            skipped += 1
+            continue
+        err = _validate_single(field_def, value)
+        if err:
+            invalid.append({"key": key, "error": err})
+            continue
+        try:
+            valid_data[key] = _coerce_value(field_def, value)
+        except (TypeError, ValueError) as exc:
+            invalid.append({"key": key, "error": f"Invalid type: {exc}"})
+    return valid_data, invalid, skipped
+
+
+def plan_settings(data: dict, mode: str = "merge") -> dict:
+    """
+    Report what ``apply_settings`` would do, without touching the store.
+
+    Restoring a whole install is not something to discover the consequences of
+    afterwards, so the restore dialog previews this first — above all the list of
+    settings replace mode would remove.  Shares its classification with the real thing
+    so the preview and the write cannot disagree.
+    """
+    before = _store.get_all()
+    valid_data, invalid, skipped = _classify_settings(data)
+    removed = (
+        _stale_keys(before, valid_data) if mode == "replace" else []
+    )
+    changed = [k for k, v in valid_data.items() if k not in before or before[k] != v]
+
+    restart_required = []
+    hot_reloaded = []
+    for key in changed + removed:
+        field_def = _resolve_schema_key(key)
+        if field_def is None:
+            continue
+        if "restart_required" in field_def.labels:
+            restart_required.append(key)
+        elif field_def.hot_reload:
+            hot_reloaded.append(key)
+
+    return {
+        "imported": len(valid_data),
+        "changed": len(changed),
+        "removed": removed,
+        "skipped": skipped,
+        "invalid": invalid,
+        "restart_required": restart_required,
+        "hot_reloaded": hot_reloaded,
+        "warnings": _check_dependencies(valid_data) if valid_data else [],
+    }
 
 
 def apply_settings(data: dict, mode: str = "merge") -> dict:
@@ -294,37 +374,14 @@ def apply_settings(data: dict, mode: str = "merge") -> dict:
         ``restart_required``, ``hot_reloaded``, ``warnings``.
     """
     before = _store.get_all()
-
-    # Validate before writing anything.  A single out-of-range value in an old backup
-    # must not abort the restore, so offenders are reported and skipped individually.
-    valid_data = {}
-    invalid = []
-    skipped = 0
-    for key, value in data.items():
-        # Internal bookkeeping keys and file metadata are not settings, and are not
-        # "unknown keys" either — counting them as skipped makes re-importing your own
-        # export look like it lost something.
-        if key.startswith("_") or key in _DATASET_KEYS:
-            continue
-        field_def = _resolve_schema_key(key)
-        if field_def is None:
-            skipped += 1
-            continue
-        err = _validate_single(field_def, value)
-        if err:
-            invalid.append({"key": key, "error": err})
-            continue
-        try:
-            valid_data[key] = _coerce_value(field_def, value)
-        except (TypeError, ValueError) as exc:
-            invalid.append({"key": key, "error": f"Invalid type: {exc}"})
+    valid_data, invalid, skipped = _classify_settings(data)
 
     removed = _remove_stale_keys(before, valid_data) if mode == "replace" else []
 
     count = _store.set_batch(valid_data) if valid_data else 0
     _module.rebuild_config()
 
-    restart_required, hot_reloaded = _replay_changes(before, valid_data, removed)
+    restart_required, hot_reloaded, changed = _replay_changes(before, valid_data, removed)
 
     # Persist restart-required fields so the banner survives a page reload, matching
     # what update_config() does after a normal save.
@@ -347,6 +404,7 @@ def apply_settings(data: dict, mode: str = "merge") -> dict:
 
     return {
         "imported": count,
+        "changed": changed,
         "removed": removed,
         "skipped": skipped,
         "invalid": invalid,
@@ -356,9 +414,9 @@ def apply_settings(data: dict, mode: str = "merge") -> dict:
     }
 
 
-def _remove_stale_keys(before: dict, valid_data: dict) -> list[str]:
+def _stale_keys(before: dict, valid_data: dict) -> list[str]:
     """
-    Delete stored settings that the imported file does not contain.
+    Stored settings that the imported file does not contain.
 
     Only keys ``export_config()`` would have written are eligible, which makes replace
     the exact inverse of export.  Two kinds of key are therefore left alone:
@@ -369,13 +427,18 @@ def _remove_stale_keys(before: dict, valid_data: dict) -> list[str]:
       migration fallback by the merger.  The indexed ``pv_forecast.0.*`` keys take
       precedence over it, so it is inert rather than stale.
     """
-    stale = [
+    return [
         key
         for key in before
         if not key.startswith("_")
         and key not in valid_data
         and _resolve_schema_key(key) is not None
     ]
+
+
+def _remove_stale_keys(before: dict, valid_data: dict) -> list[str]:
+    """Delete the stale keys and return them."""
+    stale = _stale_keys(before, valid_data)
     for key in stale:
         _store.delete(key)
     return stale
@@ -383,14 +446,15 @@ def _remove_stale_keys(before: dict, valid_data: dict) -> list[str]:
 
 def _replay_changes(
     before: dict, valid_data: dict, removed: list[str]
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], int]:
     """
     Fire hot-reload callbacks for everything the import actually changed.
 
     ``set_batch()`` and ``delete()`` skip the store's own change callbacks so the write
     stays a single transaction; without this replay the restored values would never
-    reach the running interfaces.  Returns the changed keys split into those needing a
-    restart and those applied live, classified exactly as ``update_config()`` does.
+    reach the running interfaces.  Returns the keys needing a restart, those applied
+    live — classified exactly as ``update_config()`` does — and how many values changed
+    in total.
     """
     changes = [
         (key, before.get(key), value)
@@ -416,7 +480,7 @@ def _replay_changes(
         if notify is not None:
             notify(key, old_value, new_value)
 
-    return restart_required, hot_reloaded
+    return restart_required, hot_reloaded, len(changes)
 
 
 # ------------------------------------------------------------------

--- a/src/config_web/backup.py
+++ b/src/config_web/backup.py
@@ -36,9 +36,12 @@ SETTINGS = "settings"
 PV_YIELD_HISTORY = "pv_yield_history"
 _DATASETS = (SETTINGS, PV_YIELD_HISTORY)
 
+# Set by ConfigWebModule.start_api() before any request is served.
+# pylint: disable=invalid-name
 _store = None
 _schema = None
 _module = None
+# pylint: enable=invalid-name
 
 
 def init_backup(store, schema, module):

--- a/src/config_web/backup.py
+++ b/src/config_web/backup.py
@@ -1,0 +1,251 @@
+"""
+Backup / Restore Blueprint — whole-install backup over HTTP.
+
+Prefix: ``/api/backup``
+
+Separate from ``/api/config`` on purpose.  That pair stays config-scoped and
+byte-identical to what earlier versions produced, so files written by — and for — older
+builds keep working; this one carries everything the install holds.
+
+The file itself stays **flat**: settings sit at the top level next to the metadata and
+the dataset keys, rather than inside a ``{"settings": {...}}`` envelope.  A nested file
+handed to an older build would resolve zero top-level keys against its schema, import
+nothing, and report success — a silent no-op after a Docker rollback.  Flat, that same
+build restores every setting it recognises and skips one unknown key.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request as flask_request
+
+from .api import apply_settings, export_settings_dict, plan_settings
+
+logger = logging.getLogger("__main__")
+
+backup_bp = Blueprint("backup", __name__, url_prefix="/api/backup")
+
+_FORMAT = "eos-connect-backup"
+_VERSION = 1
+
+# Local artifacts with no meaning on another install.  The meter counter is excluded for
+# a stronger reason — see PvYieldStore.plan_import.
+_ROW_FIELDS_NOT_EXPORTED = ("id", "created_at", "real_counter_kwh")
+
+SETTINGS = "settings"
+PV_YIELD_HISTORY = "pv_yield_history"
+_DATASETS = (SETTINGS, PV_YIELD_HISTORY)
+
+_store = None
+_schema = None
+_module = None
+
+
+def init_backup(store, schema, module):
+    """Wire the store, schema, and module references into the blueprint."""
+    global _store, _schema, _module  # pylint: disable=global-statement
+    _store = store
+    _schema = schema
+    _module = module
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _pv_store():
+    """
+    The PvYieldStore, or None when there is none.
+
+    It is None when the table's schema init failed, and absent entirely on hosts that
+    never wired one up, so every caller degrades instead of raising.
+    """
+    return getattr(_module, "pv_yield_store", None)
+
+
+def _setting(key, fallback):
+    """A stored setting, falling back to the schema default and then to *fallback*."""
+    field_def = _schema.get(key) if _schema else None
+    default = field_def.default if field_def is not None else fallback
+    value = _store.get(key, default)
+    return fallback if value is None else value
+
+
+def _retention_days() -> int:
+    """How many days of yield history the autoscaler currently keeps."""
+    try:
+        return int(_setting("pv_autoscaling.retention_days", 7))
+    except (TypeError, ValueError):
+        return 7
+
+
+def _tz_name():
+    """The configured local timezone, used to place 'today' when seeding."""
+    return _setting("time_zone", None)
+
+
+def _requested_datasets():
+    """
+    Parse ``?include=a,b`` into the datasets to act on.
+
+    Absent means everything, so a plain URL still produces a full backup.  Unknown names
+    are dropped rather than rejected: a newer file naming a dataset this build does not
+    have should degrade, not fail.
+    """
+    raw = flask_request.args.get("include")
+    if not raw:
+        return list(_DATASETS)
+    wanted = {name.strip() for name in raw.split(",") if name.strip()}
+    return [name for name in _DATASETS if name in wanted]
+
+
+def _flag(name: str) -> bool:
+    """Read a boolean query flag."""
+    return flask_request.args.get(name, "").lower() in ("1", "true", "yes")
+
+
+def _export_rows():
+    """Every stored yield row, stripped of fields that do not travel."""
+    pv_store = _pv_store()
+    if pv_store is None:
+        return []
+    return [
+        {k: v for k, v in row.items() if k not in _ROW_FIELDS_NOT_EXPORTED}
+        for row in pv_store.get_all_history()
+    ]
+
+
+# ------------------------------------------------------------------
+# Info
+# ------------------------------------------------------------------
+
+
+@backup_bp.route("/info", methods=["GET"])
+def backup_info():
+    """Summarise what a backup taken now would contain."""
+    rows = _export_rows()
+    timestamps = sorted(row["timestamp"] for row in rows if row.get("timestamp"))
+    return jsonify(
+        {
+            "datasets": list(_DATASETS),
+            SETTINGS: {"available": True, "count": len(export_settings_dict())},
+            PV_YIELD_HISTORY: {
+                "available": _pv_store() is not None,
+                "count": len(rows),
+                "oldest": timestamps[0] if timestamps else None,
+                "newest": timestamps[-1] if timestamps else None,
+            },
+            "retention_days": _retention_days(),
+            # The export is never masked: a redacted backup could not restore.  Said
+            # here so the UI can warn before the file reaches the user's disk.
+            "contains_secrets": True,
+        }
+    )
+
+
+# ------------------------------------------------------------------
+# Export
+# ------------------------------------------------------------------
+
+
+@backup_bp.route("/export", methods=["GET"])
+def export_backup():
+    """Export the selected datasets as one flat JSON document."""
+    include = _requested_datasets()
+    payload = {}
+    if SETTINGS in include:
+        payload.update(export_settings_dict())
+
+    payload["_format"] = _FORMAT
+    payload["_version"] = _VERSION
+    payload["_exported_at"] = datetime.now(timezone.utc).isoformat()
+    payload["_datasets"] = include
+
+    if PV_YIELD_HISTORY in include:
+        payload[PV_YIELD_HISTORY] = _export_rows()
+
+    logger.info("[Backup] Exported datasets: %s", ", ".join(include) or "none")
+    return jsonify(payload)
+
+
+# ------------------------------------------------------------------
+# Import
+# ------------------------------------------------------------------
+
+
+@backup_bp.route("/import", methods=["POST"])
+def import_backup():
+    """
+    Restore a backup file, or preview what restoring it would do.
+
+    Query parameters:
+        include: Comma-separated datasets to restore.  Default: all.
+        mode: ``replace`` (default) makes the stored settings match the file exactly,
+            removing those it does not contain.  ``merge`` keeps them.
+        history_mode: ``as_is`` (default) restores yield rows at their own timestamps;
+            ``seed`` shifts them into the retention window.
+        dry_run: When set, nothing is written and the response describes what would
+            happen.  The UI always previews before it commits — a whole-install restore
+            is not something to discover the consequences of afterwards.
+    """
+    data = flask_request.get_json(silent=True)
+    if not data or not isinstance(data, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+
+    include = _requested_datasets()
+    mode = "merge" if flask_request.args.get("mode") == "merge" else "replace"
+    history_mode = "seed" if flask_request.args.get("history_mode") == "seed" else "as_is"
+    dry_run = _flag("dry_run")
+
+    result = {
+        "dry_run": dry_run,
+        "datasets": include,
+        "mode": mode,
+        "history_mode": history_mode,
+        "format": data.get("_format"),
+        "version": data.get("_version"),
+        "exported_at": data.get("_exported_at"),
+    }
+
+    if SETTINGS in include:
+        runner = plan_settings if dry_run else apply_settings
+        result[SETTINGS] = runner(data, mode=mode)
+
+    if PV_YIELD_HISTORY in include:
+        result[PV_YIELD_HISTORY] = _restore_history(data, history_mode, dry_run)
+
+    if not dry_run:
+        logger.info(
+            "[Backup] Restored %s (mode=%s, history_mode=%s)",
+            ", ".join(include) or "nothing",
+            mode,
+            history_mode,
+        )
+    return jsonify(result)
+
+
+def _restore_history(data: dict, history_mode: str, dry_run: bool) -> dict:
+    """Restore (or preview) the yield rows a backup carries."""
+    pv_store = _pv_store()
+    rows = data.get(PV_YIELD_HISTORY)
+    if pv_store is None:
+        return {
+            "available": False,
+            "imported": 0,
+            "present_in_file": len(rows) if isinstance(rows, list) else 0,
+        }
+
+    retention_days = _retention_days()
+    kwargs = {
+        "retention_days": retention_days,
+        "tz_name": _tz_name(),
+        "mode": history_mode,
+    }
+    plan = (
+        pv_store.plan_import(rows, **kwargs)
+        if dry_run
+        else pv_store.import_rows(rows, **kwargs)
+    )
+    plan.pop("rows", None)
+    return {**plan, "available": True, "retention_days": retention_days}

--- a/src/config_web/backup.py
+++ b/src/config_web/backup.py
@@ -89,12 +89,14 @@ def _requested_datasets():
     """
     Parse ``?include=a,b`` into the datasets to act on.
 
-    Absent means everything, so a plain URL still produces a full backup.  Unknown names
-    are dropped rather than rejected: a newer file naming a dataset this build does not
-    have should degrade, not fail.
+    An *absent* parameter means everything, so a plain URL still produces a full backup.
+    An *empty* one means nothing — the two must not collapse together, or a UI that has
+    deselected every dataset would ask for none and be handed all of them.  Unknown
+    names are dropped rather than rejected: a newer file naming a dataset this build
+    does not have should degrade, not fail.
     """
     raw = flask_request.args.get("include")
-    if not raw:
+    if raw is None:
         return list(_DATASETS)
     wanted = {name.strip() for name in raw.split(",") if name.strip()}
     return [name for name in _DATASETS if name in wanted]

--- a/src/interfaces/pv_autoscaler.py
+++ b/src/interfaces/pv_autoscaler.py
@@ -36,6 +36,19 @@ TIMEFRAME_IDS = (1, 2, 3, 4)
 MAX_MISSED_HOURS = 48
 
 
+def _day_origin(origins: set) -> str:
+    """
+    Reduce a day's row origins to one label for the UI.
+
+    A day counts as measured as soon as one of its hours was recorded here, so a
+    restored day that live collection has since topped up stops being labelled as
+    seeded. Only a day made entirely of restored rows keeps their label.
+    """
+    if not origins or None in origins:
+        return "measured"
+    return "seeded" if "seeded" in origins else "imported"
+
+
 def timeframe_for_hour(hour: int) -> int:
     """Return the timeframe id (1..4) that a local hour-of-day belongs to."""
     return (int(hour) // TIMEFRAME_HOURS) + 1
@@ -680,15 +693,17 @@ class PvAutoscaler:
             timeframe = row.get("timeframe_id")
             real_delta = row.get("real_delta_kwh")
             forecast_kwh = row.get("forecast_kwh")
+            origin = row.get("origin")
         else:
             # row tuple: id, timestamp, date, hour, timeframe_id, real_counter_kwh,
             # real_delta_kwh, forecast_kwh, created_at, local_date, local_hour,
-            # local_offset_minutes
+            # local_offset_minutes, origin
             date = row[9] if len(row) > 9 and row[9] else row[2]
             hour = row[10] if len(row) > 10 and row[10] is not None else row[3]
             timeframe = row[4]
             real_delta = row[6]
             forecast_kwh = row[7]
+            origin = row[12] if len(row) > 12 else None
 
         if date is None:
             return None
@@ -706,6 +721,9 @@ class PvAutoscaler:
             "timeframe": tf,
             "real_delta_kwh": real_delta,
             "forecast_kwh": forecast_kwh,
+            # NULL for hours measured here; "imported" or "seeded" for a restored
+            # backup, which the UI must label rather than pass off as measured.
+            "origin": origin,
         }
 
     def _aggregate_by_day_and_timeframe(self, rows, keep_date, count_hours=False):
@@ -714,10 +732,14 @@ class PvAutoscaler:
 
         A timeframe is present in a day's dict only when at least one row contributed a
         non-NULL value, so callers can tell "recorded as zero" apart from "not recorded".
+
+        Also returns the set of row origins seen per day, so a day restored from a
+        backup is not presented as one this system measured.
         """
         actual: Dict[str, Dict[int, float]] = defaultdict(dict)
         forecast: Dict[str, Dict[int, float]] = defaultdict(dict)
         hours: Dict[str, set] = defaultdict(set)
+        origins: Dict[str, set] = defaultdict(set)
         recorded_hours = 0
 
         for raw in rows:
@@ -725,6 +747,7 @@ class PvAutoscaler:
             if row is None or not keep_date(row["date"]):
                 continue
             date, tf = row["date"], row["timeframe"]
+            origins[date].add(row["origin"])
             if row["real_delta_kwh"] is not None:
                 bucket = actual[date]
                 bucket[tf] = bucket.get(tf, 0.0) + float(row["real_delta_kwh"])
@@ -738,7 +761,7 @@ class PvAutoscaler:
                 bucket = forecast[date]
                 bucket[tf] = bucket.get(tf, 0.0) + float(row["forecast_kwh"])
 
-        return actual, forecast, hours, recorded_hours
+        return actual, forecast, hours, recorded_hours, origins
 
     def compute_timeframe_scaling_factors(self) -> Dict[int, float]:
         """Compute scale factors for each timeframe (1..4) based on historical data."""
@@ -748,7 +771,7 @@ class PvAutoscaler:
 
         # Today is still in progress, so it is collected but never scored.
         today_date = self._today_local_iso()
-        per_day_actual, per_day_forecast, _, recorded_hours = (
+        per_day_actual, per_day_forecast, _, recorded_hours, _origins = (
             self._aggregate_by_day_and_timeframe(rows, lambda d: d != today_date)
         )
 
@@ -811,8 +834,8 @@ class PvAutoscaler:
             return {}
 
         today_date = self._today_local_iso()
-        per_day_actual, per_day_forecast, hours, _ = self._aggregate_by_day_and_timeframe(
-            rows, lambda d: d == today_date, count_hours=True
+        per_day_actual, per_day_forecast, hours, _, _origins = (
+            self._aggregate_by_day_and_timeframe(rows, lambda d: d == today_date, count_hours=True)
         )
 
         hours_collected = hours.get(today_date, set())
@@ -842,8 +865,8 @@ class PvAutoscaler:
             return {"days": [], "summary_by_timeframe": {}}
 
         today_date = self._today_local_iso()
-        per_day_actual, per_day_forecast, hours, _ = self._aggregate_by_day_and_timeframe(
-            rows, lambda d: d != today_date, count_hours=True
+        per_day_actual, per_day_forecast, hours, _, origins = (
+            self._aggregate_by_day_and_timeframe(rows, lambda d: d != today_date, count_hours=True)
         )
 
         days = []
@@ -854,6 +877,9 @@ class PvAutoscaler:
                 {
                     "date": date,
                     "hours_collected": len(hours.get(date, set())),
+                    # "measured" unless every row for the day came from a restore, so a
+                    # day that has since been topped up by real collection reads as real.
+                    "origin": _day_origin(origins.get(date, set())),
                     "actual_kwh": {
                         str(tf): round(actual.get(tf, 0.0), 3) for tf in TIMEFRAME_IDS
                     },
@@ -901,15 +927,22 @@ class PvAutoscaler:
 
     def get_status(self) -> Dict[str, Any]:
         """Summarize the autoscaler's runtime state for the status endpoint and UI."""
+        restored_hours = 0
         try:
             rows = self._pv_yield_store.get_history_last_n_days(self.retention_days)
             total_hours = len(rows) if rows else 0
+            # Hours that came from a backup rather than this system's own meter. The UI
+            # says so, so nobody reads a seeded scale factor as a local measurement.
+            restored_hours = sum(
+                1 for row in rows or [] if (self._normalize_row(row) or {}).get("origin")
+            )
         except (AttributeError, TypeError, ValueError):
             logger.exception("[PV-AUTO] Could not read history for status")
             total_hours = 0
         return {
             "enabled": self.enabled,
             "running": self.is_running(),
+            "restored_hours": restored_hours,
             "sensor_entity_id": self.sensor_entity_id,
             "min_data_hours_required": self.min_data_hours_required,
             "retention_days": self.retention_days,

--- a/src/persistence/pv_yield_store.py
+++ b/src/persistence/pv_yield_store.py
@@ -19,6 +19,24 @@ _COLUMNS = (
     "forecast_kwh, created_at, local_date, local_hour, local_offset_minutes, origin"
 )
 
+# The shape every plan returns, so callers can read the same keys whether or not there
+# was anything to plan.
+_EMPTY_PLAN = {
+    "total": 0,
+    "rows": [],
+    "valid": 0,
+    "skipped": 0,
+    "invalid": [],
+    "outside_retention": 0,
+    "newest_local_date": None,
+    "oldest_local_date": None,
+    "age_days": None,
+    "seed_recommended": False,
+    "shift_days": 0,
+    "dropped_old": 0,
+    "collisions": 0,
+}
+
 # Provenance of a row, stored in the `origin` column. NULL means measured on this
 # system - the only kind of row that existed before backup restore was added.
 ORIGIN_MEASURED = None
@@ -116,6 +134,27 @@ def _parse_date(value) -> Optional[str]:
         return date_cls.fromisoformat(value.strip()).isoformat()
     except ValueError:
         return None
+
+
+def _coerce_rows(rows: list) -> tuple[list, list, int]:
+    """
+    Validate every exported row, keeping the good ones and counting the rest.
+
+    Returns ``(prepared, invalid, skipped)``, where *invalid* carries a capped sample of
+    rejection reasons while *skipped* stays an exact count.
+    """
+    prepared = []
+    invalid = []
+    skipped = 0
+    for index, raw in enumerate(rows):
+        row, error = _coerce_row(raw)
+        if row is None:
+            skipped += 1
+            if len(invalid) < _MAX_INVALID_DETAILS:
+                invalid.append({"index": index, "error": error})
+            continue
+        prepared.append(row)
+    return prepared, invalid, skipped
 
 
 def _shift_row(row: dict, shift_days: int, zone) -> dict:
@@ -445,38 +484,17 @@ class PvYieldStore:
             ``age_days``, ``seed_recommended``, ``shift_days``, ``dropped_old`` and
             ``collisions``.
         """
-        empty = {
-            "total": 0,
-            "rows": [],
-            "valid": 0,
-            "skipped": 0,
-            "invalid": [],
-            "outside_retention": 0,
-            "newest_local_date": None,
-            "oldest_local_date": None,
-            "age_days": None,
-            "seed_recommended": False,
-            "shift_days": 0,
-            "dropped_old": 0,
-            "collisions": 0,
-        }
         if not isinstance(rows, list) or not rows:
-            return empty
+            return dict(_EMPTY_PLAN)
 
-        prepared = []
-        invalid = []
-        skipped = 0
-        for index, raw in enumerate(rows):
-            row, error = _coerce_row(raw)
-            if row is None:
-                skipped += 1
-                if len(invalid) < _MAX_INVALID_DETAILS:
-                    invalid.append({"index": index, "error": error})
-                continue
-            prepared.append(row)
-
+        prepared, invalid, skipped = _coerce_rows(rows)
         if not prepared:
-            return {**empty, "total": len(rows), "skipped": skipped, "invalid": invalid}
+            return {
+                **_EMPTY_PLAN,
+                "total": len(rows),
+                "skipped": skipped,
+                "invalid": invalid,
+            }
 
         zone = _zone(tz_name)
         today_local = datetime.now(zone).date()

--- a/src/persistence/pv_yield_store.py
+++ b/src/persistence/pv_yield_store.py
@@ -118,6 +118,29 @@ def _parse_date(value) -> Optional[str]:
         return None
 
 
+def _shift_row(row: dict, shift_days: int, zone) -> dict:
+    """
+    Move one row forward by whole days, keeping its local wall-clock hour.
+
+    Shifting the UTC instant instead would move the local hour by an hour across a DST
+    boundary, and every consumer buckets by local date and hour. Rebuilding the local
+    time and converting back also yields the correct ``local_offset_minutes`` for the
+    new date, which is what distinguishes the two 02:00 hours of an autumn transition.
+    """
+    new_date = date_cls.fromisoformat(row["local_date"]) + timedelta(days=shift_days)
+    local = datetime(
+        new_date.year, new_date.month, new_date.day, row["local_hour"], tzinfo=zone
+    )
+    offset = local.utcoffset() or timedelta()
+    return {
+        **row,
+        "timestamp": local.astimezone(timezone.utc).isoformat(),
+        "date": new_date.isoformat(),
+        "local_date": new_date.isoformat(),
+        "local_offset_minutes": int(offset.total_seconds() // 60),
+    }
+
+
 def _coerce_row(raw) -> tuple[Optional[dict], str]:
     """
     Validate and normalise one exported row. Returns ``(row, error)``.
@@ -389,6 +412,7 @@ class PvYieldStore:
         rows: Any,
         retention_days: int = 7,
         tz_name: Optional[str] = None,
+        mode: str = "as_is",
     ) -> Dict[str, Any]:
         """
         Work out what restoring *rows* would do, without writing anything.
@@ -408,13 +432,18 @@ class PvYieldStore:
             rows: The ``pv_yield_history`` list from a backup file. Anything else yields
                 an empty plan rather than an error.
             retention_days: The window the autoscaler currently keeps.
-            tz_name: Configured local timezone, used to place "today".
+            tz_name: Configured local timezone, used to place "today" and to rebuild
+                local times when seeding.
+            mode: ``"as_is"`` restores rows at their original timestamps. ``"seed"``
+                shifts them forward so the newest lands on yesterday - see
+                ``_plan_seed``.
 
         Returns:
             A plan with ``rows`` ready for ``insert_hourly_record``, plus the counts the
             preview shows: ``total``, ``valid``, ``skipped``, ``invalid``,
             ``outside_retention``, ``newest_local_date``, ``oldest_local_date``,
-            ``age_days`` and ``seed_recommended``.
+            ``age_days``, ``seed_recommended``, ``shift_days``, ``dropped_old`` and
+            ``collisions``.
         """
         empty = {
             "total": 0,
@@ -427,6 +456,9 @@ class PvYieldStore:
             "oldest_local_date": None,
             "age_days": None,
             "seed_recommended": False,
+            "shift_days": 0,
+            "dropped_old": 0,
+            "collisions": 0,
         }
         if not isinstance(rows, list) or not rows:
             return empty
@@ -449,27 +481,87 @@ class PvYieldStore:
         zone = _zone(tz_name)
         today_local = datetime.now(zone).date()
         cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
-        outside = sum(
-            1 for row in prepared if _parse_timestamp(row["timestamp"]) < cutoff
-        )
 
         local_dates = sorted(row["local_date"] for row in prepared)
         newest = local_dates[-1]
         age_days = (today_local - date_cls.fromisoformat(newest)).days
 
-        return {
+        plan = {
             "total": len(rows),
             "rows": prepared,
             "valid": len(prepared),
             "skipped": skipped,
             "invalid": invalid,
-            "outside_retention": outside,
+            "outside_retention": sum(
+                1 for row in prepared if _parse_timestamp(row["timestamp"]) < cutoff
+            ),
             "newest_local_date": newest,
             "oldest_local_date": local_dates[0],
             "age_days": age_days,
             # Past the retention window the stored history and the backup cannot
             # overlap, which is what makes shifting the rows forward safe.
             "seed_recommended": age_days > retention_days,
+            "shift_days": 0,
+            "dropped_old": 0,
+            "collisions": 0,
+        }
+        if mode == "seed":
+            plan.update(self._plan_seed(plan, today_local, cutoff, zone))
+        return plan
+
+    def _plan_seed(
+        self, plan: Dict[str, Any], today_local: date_cls, cutoff: datetime, zone
+    ) -> Dict[str, Any]:
+        """
+        Shift a plan's rows forward so the newest one lands on yesterday.
+
+        Restoring history that predates the retention window is otherwise futile: the
+        rows are deleted at the next hourly collection and the user waits days for
+        usable scale factors to be re-learnt. Shifting the block forward keeps each
+        hour's measured/forecast ratio - which is what the factors are made of - while
+        placing it where the autoscaler still reads it.
+
+        Whole days only, so hour-of-day and therefore ``timeframe_id`` are preserved
+        exactly. Rows that still land outside the window after the shift are dropped
+        rather than written for immediate purging, and a row that would land on a
+        timestamp already present is skipped: the stored row is either a real
+        measurement or an earlier restore, and neither should be overwritten by a
+        synthetic one.
+        """
+        shift_days = (today_local - timedelta(days=1)) - date_cls.fromisoformat(
+            plan["newest_local_date"]
+        )
+        shift_days = shift_days.days
+        if shift_days <= 0:
+            return {}
+
+        occupied = {
+            row[0]
+            for row in self._store.query("SELECT timestamp FROM pv_yield_history")
+        }
+        shifted = []
+        dropped_old = 0
+        collisions = 0
+        for row in plan["rows"]:
+            moved = _shift_row(row, shift_days, zone)
+            if _parse_timestamp(moved["timestamp"]) < cutoff:
+                dropped_old += 1
+                continue
+            # Also catches two source rows collapsing onto one local hour, which the
+            # duplicated 02:00 of an autumn DST transition produces.
+            if moved["timestamp"] in occupied:
+                collisions += 1
+                continue
+            occupied.add(moved["timestamp"])
+            shifted.append(moved)
+
+        return {
+            "rows": shifted,
+            "valid": len(shifted),
+            "shift_days": shift_days,
+            "dropped_old": dropped_old,
+            "collisions": collisions,
+            "outside_retention": 0,
         }
 
     def import_rows(
@@ -477,36 +569,55 @@ class PvYieldStore:
         rows: Any,
         retention_days: int = 7,
         tz_name: Optional[str] = None,
+        mode: str = "as_is",
     ) -> Dict[str, Any]:
         """
-        Restore exported rows at their original timestamps.
+        Restore exported rows.
 
         Writes through ``insert_hourly_record``, which upserts on the UTC timestamp, so
-        re-importing the same file is idempotent. Rows already outside the retention
+        re-importing the same file is idempotent.
+
+        In ``as_is`` mode rows keep their timestamps. Any already outside the retention
         window are still written and reported: they will be purged at the next hourly
         collection, and the count tells the user to raise ``retention_days`` and try
         again rather than leaving them to vanish silently.
 
+        In ``seed`` mode the block is shifted forward into the window and marked
+        ``seeded``, so a restore made long after the backup still yields usable scale
+        factors from startup instead of days of neutral 1.0.
+
         Returns the plan counts plus ``imported``.
         """
-        plan = self.plan_import(rows, retention_days=retention_days, tz_name=tz_name)
+        plan = self.plan_import(
+            rows, retention_days=retention_days, tz_name=tz_name, mode=mode
+        )
+        # A shift of zero means seeding had nothing to do, so the rows are unmoved and
+        # should not claim to be synthetic.
+        seeded = mode == "seed" and plan["shift_days"] > 0
+        origin = ORIGIN_SEEDED if seeded else ORIGIN_IMPORTED
+
         imported = 0
         for row in plan["rows"]:
-            self.insert_hourly_record(
-                real_counter_kwh=None,
-                origin=ORIGIN_IMPORTED,
-                **row,
-            )
+            self.insert_hourly_record(real_counter_kwh=None, origin=origin, **row)
             imported += 1
 
         if imported:
             logger.info(
-                "[PV-STORE] Restored %d yield row(s), %d skipped, %d outside retention",
+                "[PV-STORE] Restored %d yield row(s) as %s (shift=%dd), "
+                "%d skipped, %d outside retention, %d dropped, %d collision(s)",
                 imported,
+                origin,
+                plan["shift_days"],
                 plan["skipped"],
                 plan["outside_retention"],
+                plan["dropped_old"],
+                plan["collisions"],
             )
-        return {**{k: v for k, v in plan.items() if k != "rows"}, "imported": imported}
+        return {
+            **{k: v for k, v in plan.items() if k != "rows"},
+            "imported": imported,
+            "origin": origin if imported else None,
+        }
 
     @staticmethod
     def _as_dict(row) -> dict:

--- a/src/persistence/pv_yield_store.py
+++ b/src/persistence/pv_yield_store.py
@@ -6,16 +6,24 @@ been predicted for that hour) in the shared SQLite database, and serves the roll
 window the autoscaler derives its scale factors from.
 """
 import logging
-from datetime import datetime, timezone
-from typing import List, Optional
+import math
+from datetime import date as date_cls, datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger("__main__")
 
 # Columns selected by every read, in the tuple order the callers unpack.
 _COLUMNS = (
     "id, timestamp, date, hour, timeframe_id, real_counter_kwh, real_delta_kwh, "
-    "forecast_kwh, created_at, local_date, local_hour, local_offset_minutes"
+    "forecast_kwh, created_at, local_date, local_hour, local_offset_minutes, origin"
 )
+
+# Provenance of a row, stored in the `origin` column. NULL means measured on this
+# system - the only kind of row that existed before backup restore was added.
+ORIGIN_MEASURED = None
+ORIGIN_IMPORTED = "imported"   # restored at its original timestamp
+ORIGIN_SEEDED = "seeded"       # restored with its timestamp shifted into the window
 
 # Timestamps are written as UTC ISO-8601 ("2026-08-22T08:00:00+00:00"), which does not
 # compare lexicographically against SQLite's datetime() output ("2026-08-22 08:00:00"):
@@ -24,6 +32,142 @@ _COLUMNS = (
 # sides instead, which is well-ordered and offset-free.
 _TS_PREFIX = "substr(timestamp, 1, 19)"
 _CUTOFF = "strftime('%Y-%m-%dT%H:%M:%S', 'now', ?)"
+
+
+# Rows arrive from a user-supplied backup file, so every field is treated as untrusted.
+# Only this many rejection reasons are kept for the response - the counts stay exact.
+_MAX_INVALID_DETAILS = 20
+
+
+def _timeframe_for_hour(hour: int) -> int:
+    """
+    Map a local hour to its timeframe 1-4.
+
+    Deliberately duplicates ``interfaces.pv_autoscaler.timeframe_for_hour`` rather than
+    importing it: at runtime the app starts as ``python eos_connect.py`` with ``src/``
+    as the root, so ``persistence`` and ``interfaces`` are sibling top-level packages
+    and a relative import across them raises ImportError. Two lines beat that hazard,
+    and ``timeframe_id`` is a column of this table anyway.
+    """
+    return (hour // 6) + 1
+
+
+def _zone(tz_name: Optional[str]):
+    """Resolve a timezone name, falling back to UTC when it is missing or unknown."""
+    if not tz_name:
+        return timezone.utc
+    try:
+        return ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, ValueError, TypeError):
+        logger.warning("[PV-STORE] Unknown time zone %r - falling back to UTC", tz_name)
+        return timezone.utc
+
+
+def _parse_timestamp(value) -> Optional[datetime]:
+    """Parse an ISO timestamp to an aware UTC datetime, or None when unusable."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip())
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _parse_kwh(value) -> tuple[bool, Optional[float]]:
+    """
+    Coerce an energy field. Returns ``(ok, value)``.
+
+    Missing is fine - the column is nullable and COALESCE keeps whatever is stored.
+    Negative or non-finite is not: it would enter the measured/forecast ratio and
+    corrupt a scale factor for the whole retention window.
+    """
+    if value is None:
+        return True, None
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        return False, None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return False, None
+    if not math.isfinite(number) or number < 0:
+        return False, None
+    return True, number
+
+
+def _parse_int(value, low: int, high: int) -> Optional[int]:
+    """Coerce an integer field and bounds-check it, or None when unusable."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if low <= number <= high else None
+
+
+def _parse_date(value) -> Optional[str]:
+    """Validate a YYYY-MM-DD date string, or None when unusable."""
+    if not isinstance(value, str):
+        return None
+    try:
+        return date_cls.fromisoformat(value.strip()).isoformat()
+    except ValueError:
+        return None
+
+
+def _coerce_row(raw) -> tuple[Optional[dict], str]:
+    """
+    Validate and normalise one exported row. Returns ``(row, error)``.
+
+    ``real_counter_kwh`` is dropped on purpose - see ``PvYieldStore.plan_import``.
+    """
+    if not isinstance(raw, dict):
+        return None, "row is not an object"
+
+    utc_ts = _parse_timestamp(raw.get("timestamp"))
+    if utc_ts is None:
+        return None, "missing or unparseable timestamp"
+
+    offset_minutes = _parse_int(raw.get("local_offset_minutes"), -1440, 1440)
+
+    # The stored local date/hour are what every consumer buckets by, so prefer them and
+    # only reconstruct from the timestamp when the row predates those columns.
+    local_hour = _parse_int(raw.get("local_hour"), 0, 23)
+    if local_hour is None:
+        local_hour = _parse_int(raw.get("hour"), 0, 23)
+    local_date = _parse_date(raw.get("local_date")) or _parse_date(raw.get("date"))
+    if local_hour is None or local_date is None:
+        derived = utc_ts + timedelta(minutes=offset_minutes or 0)
+        if local_hour is None:
+            local_hour = derived.hour
+        if local_date is None:
+            local_date = derived.date().isoformat()
+
+    timeframe_id = _parse_int(raw.get("timeframe_id"), 1, 4)
+    if timeframe_id is None:
+        timeframe_id = _timeframe_for_hour(local_hour)
+
+    real_ok, real_delta_kwh = _parse_kwh(raw.get("real_delta_kwh"))
+    if not real_ok:
+        return None, "real_delta_kwh is negative, non-finite or not a number"
+    forecast_ok, forecast_kwh = _parse_kwh(raw.get("forecast_kwh"))
+    if not forecast_ok:
+        return None, "forecast_kwh is negative, non-finite or not a number"
+
+    return {
+        "timestamp": utc_ts.isoformat(),
+        "date": local_date,
+        "hour": local_hour,
+        "timeframe_id": timeframe_id,
+        "real_delta_kwh": real_delta_kwh,
+        "forecast_kwh": forecast_kwh,
+        "local_date": local_date,
+        "local_hour": local_hour,
+        "local_offset_minutes": offset_minutes,
+    }, ""
 
 
 class PvYieldStore:
@@ -78,6 +222,9 @@ class PvYieldStore:
             ("local_date", "TEXT"),
             ("local_hour", "INTEGER"),
             ("local_offset_minutes", "INTEGER"),
+            # NULL on every pre-existing row, which is correct: they were all measured
+            # here. Only restored rows carry a value.
+            ("origin", "TEXT"),
         ):
             if name not in columns:
                 self._store.execute(
@@ -143,6 +290,7 @@ class PvYieldStore:
         local_date: Optional[str] = None,
         local_hour: Optional[int] = None,
         local_offset_minutes: Optional[int] = None,
+        origin: Optional[str] = ORIGIN_MEASURED,
     ) -> None:
         """
         Insert an hourly PV yield record, or complete the one already stored for it.
@@ -165,6 +313,9 @@ class PvYieldStore:
             local_date: Timezone-aware local date (YYYY-MM-DD).
             local_hour: Timezone-aware local hour 0-23.
             local_offset_minutes: UTC offset in minutes, distinguishing DST occurrences.
+            origin: Provenance marker for a new row - None for measured, "imported" or
+                "seeded" for a restored one. Deliberately not part of the merge below:
+                an hour measured here stays measured even if a backup later completes it.
         """
         now = datetime.now(timezone.utc).isoformat()
 
@@ -210,8 +361,8 @@ class PvYieldStore:
                 INSERT INTO pv_yield_history
                     (timestamp, date, hour, timeframe_id, real_counter_kwh,
                      real_delta_kwh, forecast_kwh, created_at, local_date, local_hour,
-                     local_offset_minutes)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     local_offset_minutes, origin)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     timestamp,
@@ -225,8 +376,137 @@ class PvYieldStore:
                     local_date,
                     local_hour,
                     local_offset_minutes,
+                    origin,
                 ),
             )
+
+    # ------------------------------------------------------------------
+    # Backup restore
+    # ------------------------------------------------------------------
+
+    def plan_import(
+        self,
+        rows: Any,
+        retention_days: int = 7,
+        tz_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Work out what restoring *rows* would do, without writing anything.
+
+        Drives the dry-run preview in the restore dialog and is reused by
+        ``import_rows`` so the preview and the write can never disagree.
+
+        ``real_counter_kwh`` is never restored. It is an absolute meter reading, and the
+        autoscaler seeds its in-memory baseline from the newest stored row on startup;
+        a restored reading would make the first live collection record the difference
+        between two unrelated meters as one hour of yield, pinning that timeframe to
+        ``max_scale_factor`` for the entire retention window. Left NULL, the autoscaler
+        simply re-establishes its baseline on the first collection. Scale factors are
+        computed from ``real_delta_kwh`` and ``forecast_kwh`` only, so nothing is lost.
+
+        Args:
+            rows: The ``pv_yield_history`` list from a backup file. Anything else yields
+                an empty plan rather than an error.
+            retention_days: The window the autoscaler currently keeps.
+            tz_name: Configured local timezone, used to place "today".
+
+        Returns:
+            A plan with ``rows`` ready for ``insert_hourly_record``, plus the counts the
+            preview shows: ``total``, ``valid``, ``skipped``, ``invalid``,
+            ``outside_retention``, ``newest_local_date``, ``oldest_local_date``,
+            ``age_days`` and ``seed_recommended``.
+        """
+        empty = {
+            "total": 0,
+            "rows": [],
+            "valid": 0,
+            "skipped": 0,
+            "invalid": [],
+            "outside_retention": 0,
+            "newest_local_date": None,
+            "oldest_local_date": None,
+            "age_days": None,
+            "seed_recommended": False,
+        }
+        if not isinstance(rows, list) or not rows:
+            return empty
+
+        prepared = []
+        invalid = []
+        skipped = 0
+        for index, raw in enumerate(rows):
+            row, error = _coerce_row(raw)
+            if row is None:
+                skipped += 1
+                if len(invalid) < _MAX_INVALID_DETAILS:
+                    invalid.append({"index": index, "error": error})
+                continue
+            prepared.append(row)
+
+        if not prepared:
+            return {**empty, "total": len(rows), "skipped": skipped, "invalid": invalid}
+
+        zone = _zone(tz_name)
+        today_local = datetime.now(zone).date()
+        cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+        outside = sum(
+            1 for row in prepared if _parse_timestamp(row["timestamp"]) < cutoff
+        )
+
+        local_dates = sorted(row["local_date"] for row in prepared)
+        newest = local_dates[-1]
+        age_days = (today_local - date_cls.fromisoformat(newest)).days
+
+        return {
+            "total": len(rows),
+            "rows": prepared,
+            "valid": len(prepared),
+            "skipped": skipped,
+            "invalid": invalid,
+            "outside_retention": outside,
+            "newest_local_date": newest,
+            "oldest_local_date": local_dates[0],
+            "age_days": age_days,
+            # Past the retention window the stored history and the backup cannot
+            # overlap, which is what makes shifting the rows forward safe.
+            "seed_recommended": age_days > retention_days,
+        }
+
+    def import_rows(
+        self,
+        rows: Any,
+        retention_days: int = 7,
+        tz_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Restore exported rows at their original timestamps.
+
+        Writes through ``insert_hourly_record``, which upserts on the UTC timestamp, so
+        re-importing the same file is idempotent. Rows already outside the retention
+        window are still written and reported: they will be purged at the next hourly
+        collection, and the count tells the user to raise ``retention_days`` and try
+        again rather than leaving them to vanish silently.
+
+        Returns the plan counts plus ``imported``.
+        """
+        plan = self.plan_import(rows, retention_days=retention_days, tz_name=tz_name)
+        imported = 0
+        for row in plan["rows"]:
+            self.insert_hourly_record(
+                real_counter_kwh=None,
+                origin=ORIGIN_IMPORTED,
+                **row,
+            )
+            imported += 1
+
+        if imported:
+            logger.info(
+                "[PV-STORE] Restored %d yield row(s), %d skipped, %d outside retention",
+                imported,
+                plan["skipped"],
+                plan["outside_retention"],
+            )
+        return {**{k: v for k, v in plan.items() if k != "rows"}, "imported": imported}
 
     @staticmethod
     def _as_dict(row) -> dict:
@@ -243,6 +523,7 @@ class PvYieldStore:
             "local_date": row[9],
             "local_hour": row[10],
             "local_offset_minutes": row[11],
+            "origin": row[12],
         }
 
     def get_latest_record(self) -> Optional[dict]:
@@ -259,6 +540,17 @@ class PvYieldStore:
             f"WHERE {_TS_PREFIX} >= {_CUTOFF} "
             "ORDER BY timestamp ASC",
             (f"-{days} days",),
+        )
+        return [self._as_dict(row) for row in rows]
+
+    def get_all_history(self) -> List[dict]:
+        """Return every stored hour, oldest first, ignoring any retention window.
+
+        Used by backup export, which must capture whatever is on disk rather than only
+        the days the autoscaler currently scores.
+        """
+        rows = self._store.query(
+            f"SELECT {_COLUMNS} FROM pv_yield_history ORDER BY timestamp ASC"
         )
         return [self._as_dict(row) for row in rows]
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -440,6 +440,7 @@
     <script src="js/battery.js?v={{ asset_version }}"></script>
     <script src="js/logging.js?v={{ asset_version }}"></script>
     <script src="js/config.js?v={{ asset_version }}"></script>
+    <script src="js/backup.js?v={{ asset_version }}"></script>
     <script src="js/wizard.js?v={{ asset_version }}"></script>
     <script src="js/update_banner.js?v={{ asset_version }}"></script>
     <script src="js/main.js?v={{ asset_version }}"></script>

--- a/src/web/js/backup.js
+++ b/src/web/js/backup.js
@@ -1,0 +1,843 @@
+/**
+ * Backup & Restore panel.
+ *
+ * Saves and restores the whole install — configuration plus the measured PV yield
+ * history the autoscaler learns from. The configuration section keeps its own
+ * export/import buttons; those stay config-only.
+ *
+ * A restore is always previewed before it is applied. It can remove settings and
+ * overwrite a working configuration, which is not something to discover afterwards.
+ */
+
+const BACKUP_DATASETS = [
+    {
+        key: "settings",
+        label: "Configuration",
+        icon: "fa-gear",
+        hint: "Every setting on this install",
+    },
+    {
+        key: "pv_yield_history",
+        label: "PV yield history",
+        icon: "fa-solar-panel",
+        hint: "Measured hourly yield the auto-scaler learns from",
+    },
+];
+
+class BackupManager {
+    /**
+     * Initialize BackupManager.
+     */
+    constructor() {
+        this.info = null;          // GET /api/backup/info
+        // Kept apart on purpose: the two cards are separate decisions, and sharing one
+        // set made ticking a box under Restore change what Download would write.
+        this.forBackup = { settings: true, pv_yield_history: true };
+        this.forRestore = { settings: true, pv_yield_history: true };
+        this.mode = "replace";     // settings: replace | merge
+        this.historyMode = "as_is"; // yield rows: as_is | seed
+        this.pending = null;       // parsed file awaiting confirmation
+        this.preview = null;       // dry-run result for this.pending
+        this.result = null;        // outcome of the last applied restore
+        this.busy = false;
+    }
+
+    // ── Public entry point ──────────────────────────────────────
+
+    /**
+     * Show the Backup & Restore overlay.
+     */
+    async showBackupMenu() {
+        this.pending = null;
+        this.preview = null;
+        this.result = null;
+
+        showFullScreenOverlay(this._header(), this._loading("Reading backup contents…"));
+        try {
+            const res = await fetch("api/backup/info");
+            if (!res.ok) {
+                throw new Error(`status ${res.status}`);
+            }
+            this.info = await res.json();
+            this._render();
+        } catch (err) {
+            this._renderInto(this._error(
+                "Could not read what this install holds.",
+                err.message || err
+            ));
+        }
+    }
+
+    // ── Rendering ───────────────────────────────────────────────
+
+    /**
+     * Overlay header markup.
+     * @returns {string} HTML
+     */
+    _header() {
+        return `
+            <div style="display:flex;align-items:center;gap:10px;">
+                <i class="fa-solid fa-box-archive" style="color:#cccccc;"></i>
+                <span>Backup &amp; Restore</span>
+            </div>`;
+    }
+
+    /**
+     * Replace the overlay body.
+     * @param {string} html - Body markup
+     */
+    _renderInto(html) {
+        const content = document.getElementById("full_screen_content");
+        if (content) {
+            content.innerHTML = html;
+        }
+    }
+
+    /**
+     * Render the whole panel from current state.
+     */
+    _render() {
+        this._renderInto(`
+            <div style="max-width:820px;margin:0 auto;display:flex;flex-direction:column;gap:18px;">
+                ${this._backupCard()}
+                ${this._restoreCard()}
+            </div>`);
+    }
+
+    /**
+     * "Create a backup" card.
+     * @returns {string} HTML
+     */
+    _backupCard() {
+        const history = (this.info && this.info.pv_yield_history) || {};
+        const settings = (this.info && this.info.settings) || {};
+        const span = history.oldest && history.newest
+            ? `${this._day(history.oldest)} → ${this._day(history.newest)}`
+            : "nothing recorded yet";
+
+        const counts = [
+            `<div style="display:flex;justify-content:space-between;gap:12px;">
+                <span><i class="fa-solid fa-gear" style="width:18px;color:#888;"></i>
+                Configuration</span>
+                <span style="color:#bbb;">${settings.count || 0} settings</span>
+            </div>`,
+            `<div style="display:flex;justify-content:space-between;gap:12px;">
+                <span><i class="fa-solid fa-solar-panel" style="width:18px;color:#888;"></i>
+                PV yield history</span>
+                <span style="color:#bbb;">${history.available === false
+                    ? "unavailable"
+                    : `${history.count || 0} hours · ${this._escape(span)}`}</span>
+            </div>`,
+        ].join("");
+
+        return this._card("fa-download", "Create a backup", `
+            <div style="display:flex;flex-direction:column;gap:8px;font-size:0.92em;">
+                ${counts}
+            </div>
+            ${this._datasetPicker("backup")}
+            ${this._warning(`
+                The backup file contains your access tokens and inverter password in
+                <strong>plain text</strong>. It has to — a masked file could not restore.
+                Keep it somewhere you would keep a password.
+            `)}
+            <div style="margin-top:14px;">
+                <button onclick="backupManager._download()" class="config-btn"
+                        style="background:#4a9eff;color:#fff;border:none;border-radius:6px;
+                               padding:9px 16px;cursor:pointer;font-size:0.9em;">
+                    <i class="fas fa-download"></i> Download backup
+                </button>
+            </div>
+        `);
+    }
+
+    /**
+     * "Restore from a backup" card — picker, preview or result depending on state.
+     * @returns {string} HTML
+     */
+    _restoreCard() {
+        if (this.result) {
+            return this._card("fa-check", "Restore complete", this._resultBody());
+        }
+        if (this.preview) {
+            return this._card("fa-list-check", "Review before restoring", this._previewBody());
+        }
+        return this._card("fa-upload", "Restore from a backup", `
+            <p style="margin:0 0 12px;color:#bbb;font-size:0.9em;">
+                Pick a backup file. Nothing is written until you confirm what it would do.
+            </p>
+            <input type="file" id="backup-restore-file" accept=".json" style="display:none;"
+                   onchange="backupManager._pick(this.files[0])">
+            <button onclick="document.getElementById('backup-restore-file').click()"
+                    style="background:#5a5a5a;color:#e0e0e0;border:1px solid rgba(255,255,255,0.15);
+                           border-radius:6px;padding:9px 16px;cursor:pointer;font-size:0.9em;">
+                <i class="fas fa-folder-open"></i> Choose backup file…
+            </button>
+        `);
+    }
+
+    /**
+     * The dry-run preview: what a restore would change.
+     * @returns {string} HTML
+     */
+    _previewBody() {
+        const p = this.preview;
+        const settings = p.settings;
+        const history = p.pv_yield_history;
+        const rows = [];
+
+        rows.push(this._metaRow("File", this._escape(this.pending.name)));
+        rows.push(this._metaRow("Written", p.exported_at
+            ? this._escape(this._day(p.exported_at))
+            : "<span style='color:#ffc107;'>unknown — older config export</span>"));
+
+        if (settings) {
+            rows.push(this._metaRow("Settings to write", `${settings.imported}
+                (${settings.changed} changed)`));
+            if (settings.removed.length) {
+                rows.push(this._metaRow(
+                    "Settings to remove",
+                    `<span style="color:#ffc107;">${settings.removed.length}</span>`
+                ));
+            }
+            if (settings.invalid.length) {
+                rows.push(this._metaRow(
+                    "Values rejected",
+                    `<span style="color:#ffc107;">${settings.invalid.length} — skipped</span>`
+                ));
+            }
+        }
+        if (history && history.available !== false) {
+            rows.push(this._metaRow("Yield hours in file", `${history.total || 0}`));
+            if (history.skipped) {
+                rows.push(this._metaRow(
+                    "Yield rows unusable",
+                    `<span style="color:#ffc107;">${history.skipped} — skipped</span>`
+                ));
+            }
+        }
+
+        return `
+            <div style="display:flex;flex-direction:column;gap:6px;font-size:0.9em;">
+                ${rows.join("")}
+            </div>
+            ${this._datasetPicker("restore")}
+            ${this._modePicker()}
+            ${this._historyPicker()}
+            ${this._removalWarning()}
+            ${this._invalidWarning()}
+            ${this._anySelectedForRestore() ? "" : this._warning(
+                "Nothing is selected, so there is nothing to restore."
+            )}
+            <div style="margin-top:16px;display:flex;gap:10px;flex-wrap:wrap;">
+                <button onclick="backupManager._confirm()"
+                        ${this.busy || !this._anySelectedForRestore() ? "disabled" : ""}
+                        style="background:#4a9eff;color:#fff;border:none;border-radius:6px;
+                               padding:9px 16px;cursor:pointer;font-size:0.9em;
+                               opacity:${this.busy || !this._anySelectedForRestore()
+                                   ? "0.6" : "1"};">
+                    <i class="fas fa-check"></i> Restore now
+                </button>
+                <button onclick="backupManager._cancel()"
+                        style="background:transparent;color:#bbb;border:1px solid rgba(255,255,255,0.2);
+                               border-radius:6px;padding:9px 16px;cursor:pointer;font-size:0.9em;">
+                    Cancel
+                </button>
+            </div>`;
+    }
+
+    /**
+     * What the restore actually did.
+     * @returns {string} HTML
+     */
+    _resultBody() {
+        const r = this.result;
+        const settings = r.settings;
+        const history = r.pv_yield_history;
+        const lines = [];
+
+        if (settings) {
+            lines.push(this._metaRow("Settings restored", `${settings.imported}`));
+            if (settings.removed.length) {
+                lines.push(this._metaRow("Settings removed", `${settings.removed.length}`));
+            }
+            if (settings.invalid.length) {
+                lines.push(this._metaRow(
+                    "Values skipped",
+                    `<span style="color:#ffc107;">${settings.invalid.length}</span>`
+                ));
+            }
+        }
+        if (history && history.available !== false) {
+            lines.push(this._metaRow("Yield hours restored", `${history.imported || 0}`));
+            if (history.shift_days > 0) {
+                lines.push(this._metaRow(
+                    "History shifted",
+                    `${history.shift_days} day(s) forward — marked as seeded`
+                ));
+            }
+            if (history.collisions) {
+                lines.push(this._metaRow(
+                    "Hours already measured here",
+                    `${history.collisions} — left untouched`
+                ));
+            }
+            if (history.dropped_old) {
+                lines.push(this._metaRow(
+                    "Hours too old to keep",
+                    `${history.dropped_old} — not written`
+                ));
+            }
+        }
+
+        const restart = (settings && settings.restart_required) || [];
+        const outside = history ? history.outside_retention : 0;
+
+        return `
+            <div style="display:flex;flex-direction:column;gap:6px;font-size:0.9em;">
+                ${lines.join("")}
+            </div>
+            ${restart.length ? this._warning(`
+                <strong>Restart required.</strong> ${restart.length} restored setting(s)
+                only take effect after EOS connect restarts. Everything else is already live.
+            `) : ""}
+            ${outside ? this._warning(`
+                ${outside} restored hour(s) fall outside the ${history.retention_days}-day
+                retention window and will be deleted at the next collection. Raise
+                <em>PV auto-scaling → retention days</em> and restore again to keep them,
+                or restore with time-shifting.
+            `) : ""}
+            <div style="margin-top:16px;display:flex;gap:10px;">
+                <button onclick="backupManager.showBackupMenu()"
+                        style="background:#5a5a5a;color:#e0e0e0;border:1px solid rgba(255,255,255,0.15);
+                               border-radius:6px;padding:9px 16px;cursor:pointer;font-size:0.9em;">
+                    Done
+                </button>
+            </div>`;
+    }
+
+    // ── Pickers ─────────────────────────────────────────────────
+
+    /**
+     * Dataset checkboxes.
+     * @param {string} scope - "backup" or "restore", used only for input ids
+     * @returns {string} HTML
+     */
+    _datasetPicker(scope) {
+        const selection = scope === "backup" ? this.forBackup : this.forRestore;
+        const items = BACKUP_DATASETS.map(ds => {
+            const unavailable = ds.key === "pv_yield_history"
+                && this.info && this.info.pv_yield_history
+                && this.info.pv_yield_history.available === false;
+            return `
+                <label style="display:flex;align-items:flex-start;gap:9px;cursor:${
+                    unavailable ? "not-allowed" : "pointer"};opacity:${unavailable ? "0.5" : "1"};">
+                    <input type="checkbox" id="ds-${scope}-${ds.key}"
+                           ${selection[ds.key] && !unavailable ? "checked" : ""}
+                           ${unavailable ? "disabled" : ""}
+                           onchange="backupManager._toggle('${scope}', '${ds.key}', this.checked)"
+                           style="margin-top:3px;">
+                    <span>
+                        <i class="fa-solid ${ds.icon}" style="width:18px;color:#888;"></i>
+                        ${ds.label}
+                        <span style="display:block;margin-left:26px;color:#8d8d8d;font-size:0.82em;">
+                            ${ds.hint}
+                        </span>
+                    </span>
+                </label>`;
+        }).join("");
+
+        return `<div style="margin-top:14px;display:flex;flex-direction:column;gap:10px;
+                            font-size:0.9em;">${items}</div>`;
+    }
+
+    /**
+     * Merge / replace choice for settings.
+     * @returns {string} HTML
+     */
+    _modePicker() {
+        if (!this.forRestore.settings) {
+            return "";
+        }
+        return this._choice("How to restore the configuration", [
+            {
+                value: "replace",
+                checked: this.mode === "replace",
+                label: "Replace",
+                hint: "The configuration ends up exactly as in the file. Settings the file "
+                    + "does not contain are removed and fall back to their defaults.",
+                on: "backupManager._setMode('replace')",
+            },
+            {
+                value: "merge",
+                checked: this.mode === "merge",
+                label: "Merge",
+                hint: "Apply what the file contains and leave everything else as it is.",
+                on: "backupManager._setMode('merge')",
+            },
+        ]);
+    }
+
+    /**
+     * As-is / seed choice for the yield history.
+     * @returns {string} HTML
+     */
+    _historyPicker() {
+        const history = this.preview && this.preview.pv_yield_history;
+        if (!this.forRestore.pv_yield_history || !history || history.available === false
+            || !history.valid) {
+            return "";
+        }
+        const stale = history.seed_recommended;
+        const shift = history.shift_days || 0;
+        const seedHint = stale
+            ? `The newest measurement in this file is ${history.age_days} days old — past the
+               ${history.retention_days}-day window, so it would be deleted at the next
+               collection. Shifting it ${shift || "a few"} day(s) forward keeps each hour's
+               measured-to-forecast ratio and gives you working scale factors immediately.
+               The rows are marked as seeded, not measured here.`
+            : `Not recommended for this file: it is only ${history.age_days} day(s) old, so
+               the shifted hours could land beside days this system already measured and
+               count the same yield twice.`;
+
+        return this._choice("How to restore the measured history", [
+            {
+                value: "as_is",
+                checked: this.historyMode === "as_is",
+                label: "Keep original dates",
+                hint: "Restore each hour at the time it was recorded.",
+                on: "backupManager._setHistoryMode('as_is')",
+            },
+            {
+                value: "seed",
+                checked: this.historyMode === "seed",
+                label: `Shift into the current window${stale ? " — recommended" : ""}`,
+                hint: seedHint,
+                on: "backupManager._setHistoryMode('seed')",
+            },
+        ]);
+    }
+
+    /**
+     * Spell out which settings replace mode would remove.
+     * @returns {string} HTML
+     */
+    _removalWarning() {
+        const settings = this.preview && this.preview.settings;
+        if (!settings || !settings.removed.length) {
+            return "";
+        }
+        const shown = settings.removed.slice(0, 25).map(k => this._escape(k)).join(", ");
+        const rest = settings.removed.length - 25;
+        return this._warning(`
+            <strong>${settings.removed.length} setting(s) will be removed</strong> and revert
+            to their defaults, because this file does not contain them. This is normal when
+            the backup came from an older version.
+            <div style="margin-top:8px;font-family:monospace;font-size:0.85em;color:#ddd;
+                        word-break:break-all;">${shown}${rest > 0 ? ` … +${rest} more` : ""}</div>
+        `);
+    }
+
+    /**
+     * List values the backend refused.
+     * @returns {string} HTML
+     */
+    _invalidWarning() {
+        const settings = this.preview && this.preview.settings;
+        if (!settings || !settings.invalid.length) {
+            return "";
+        }
+        const shown = settings.invalid.slice(0, 10)
+            .map(e => `${this._escape(e.key)}: ${this._escape(e.error)}`)
+            .join("<br>");
+        return this._warning(`
+            <strong>${settings.invalid.length} value(s) will be skipped</strong> —
+            they are no longer valid for this version. Everything else still restores.
+            <div style="margin-top:8px;font-size:0.85em;color:#ddd;">${shown}</div>
+        `);
+    }
+
+    // ── Actions ─────────────────────────────────────────────────
+
+    /**
+     * Toggle a dataset on or off.
+     * @param {string} scope - "backup" or "restore"
+     * @param {string} key - Dataset key
+     * @param {boolean} on - New state
+     */
+    _toggle(scope, key, on) {
+        if (scope === "backup") {
+            this.forBackup[key] = on;
+            this._render();
+            return;
+        }
+        this.forRestore[key] = on;
+        // The preview is scoped to the selected datasets, so it has to be recomputed
+        // rather than left showing counts for a selection that no longer applies.
+        this._refreshPreview();
+    }
+
+    /**
+     * Set the settings restore mode.
+     * @param {string} mode - "replace" or "merge"
+     */
+    _setMode(mode) {
+        this.mode = mode;
+        this._refreshPreview();
+    }
+
+    /**
+     * Set the yield history restore mode.
+     * @param {string} mode - "as_is" or "seed"
+     */
+    _setHistoryMode(mode) {
+        this.historyMode = mode;
+        this._refreshPreview();
+    }
+
+    /**
+     * Whether at least one dataset is ticked for restoring.
+     * @returns {boolean} True when there is something to do
+     */
+    _anySelectedForRestore() {
+        return Object.values(this.forRestore).some(Boolean);
+    }
+
+    /**
+     * Build the query string both preview and apply use.
+     * @param {boolean} dryRun - Whether to ask for a preview only
+     * @returns {string} Query string
+     */
+    _query(dryRun) {
+        const include = Object.keys(this.forRestore)
+            .filter(k => this.forRestore[k])
+            .join(",");
+        const params = [
+            `include=${encodeURIComponent(include)}`,
+            `mode=${this.mode}`,
+            `history_mode=${this.historyMode}`,
+        ];
+        if (dryRun) {
+            params.push("dry_run=1");
+        }
+        return `?${params.join("&")}`;
+    }
+
+    /**
+     * Download the selected datasets as a file.
+     */
+    async _download() {
+        const include = Object.keys(this.forBackup).filter(k => this.forBackup[k]);
+        if (!include.length) {
+            this._toast("Select at least one thing to back up.", "warning");
+            return;
+        }
+        try {
+            const res = await fetch(`api/backup/export?include=${include.join(",")}`);
+            if (!res.ok) {
+                throw new Error(`status ${res.status}`);
+            }
+            const data = await res.json();
+            const blob = new Blob([JSON.stringify(data, null, 2)], {
+                type: "application/json",
+            });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `eos_connect_backup_${new Date().toISOString().slice(0, 10)}.json`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            this._toast("Backup downloaded. Keep it somewhere safe — it holds your tokens.",
+                "success", 6000);
+        } catch (err) {
+            this._toast("Backup failed: " + (err.message || err), "error");
+        }
+    }
+
+    /**
+     * Parse a chosen file and ask the backend what restoring it would do.
+     * @param {File} file - The selected file
+     */
+    async _pick(file) {
+        if (!file) {
+            return;
+        }
+        let data;
+        try {
+            data = JSON.parse(await file.text());
+        } catch (err) {
+            this._toast("That file is not valid JSON.", "error");
+            return;
+        }
+        if (typeof data !== "object" || data === null || Array.isArray(data)) {
+            this._toast("That file does not look like a backup.", "error");
+            return;
+        }
+
+        this.pending = { name: file.name, data };
+        // A file with no history section has nothing to restore into that dataset.
+        if (!Array.isArray(data.pv_yield_history) || !data.pv_yield_history.length) {
+            this.forRestore.pv_yield_history = false;
+        }
+        await this._refreshPreview(true);
+    }
+
+    /**
+     * Re-run the dry run for the current file and options.
+     * @param {boolean} firstTime - Whether this is the initial preview for a new file
+     */
+    async _refreshPreview(firstTime = false) {
+        if (!this.pending) {
+            return;
+        }
+        if (!this._anySelectedForRestore()) {
+            // Nothing to preview, but keep the card on screen so the user can tick
+            // something back on rather than losing the chosen file.
+            this._render();
+            return;
+        }
+        try {
+            const res = await fetch(`api/backup/import${this._query(true)}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(this.pending.data),
+            });
+            const preview = await res.json();
+            if (!res.ok) {
+                throw new Error(preview.error || `status ${res.status}`);
+            }
+            this.preview = preview;
+            // Offer the shift by default when the file is too old to be useful as-is,
+            // which is also the only case where it cannot duplicate measured days.
+            const history = preview.pv_yield_history;
+            if (firstTime && history && history.seed_recommended) {
+                this.historyMode = "seed";
+                await this._refreshPreview();
+                return;
+            }
+            this._render();
+        } catch (err) {
+            this._toast("Could not read that backup: " + (err.message || err), "error");
+        }
+    }
+
+    /**
+     * Apply the previewed restore.
+     */
+    async _confirm() {
+        if (!this.pending || this.busy || !this._anySelectedForRestore()) {
+            return;
+        }
+        this.busy = true;
+        this._render();
+        try {
+            const res = await fetch(`api/backup/import${this._query(false)}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(this.pending.data),
+            });
+            const result = await res.json();
+            if (!res.ok) {
+                throw new Error(result.error || `status ${res.status}`);
+            }
+            this.result = result;
+            this.preview = null;
+            this.pending = null;
+            this._render();
+            this._afterRestore(result);
+        } catch (err) {
+            this._toast("Restore failed: " + (err.message || err), "error");
+        } finally {
+            this.busy = false;
+            if (!this.result) {
+                this._render();   // re-enable the button after a failure
+            }
+        }
+    }
+
+    /**
+     * Discard a pending restore.
+     */
+    _cancel() {
+        this.pending = null;
+        this.preview = null;
+        this._render();
+    }
+
+    /**
+     * Refresh the rest of the UI so it reflects the restored config.
+     * @param {object} result - The import response
+     */
+    _afterRestore(result) {
+        const restart = (result.settings && result.settings.restart_required) || [];
+        if (restart.length && typeof MenuNotifications !== "undefined") {
+            MenuNotifications.setRestartPending(true);
+        }
+        if (typeof configurationManager !== "undefined" && configurationManager) {
+            // Drop the cached schema values so reopening Configuration shows the
+            // restored config rather than what was on screen before.
+            configurationManager.values = {};
+            configurationManager.originalValues = {};
+            configurationManager.restartFields = restart;
+        }
+    }
+
+    // ── Small helpers ───────────────────────────────────────────
+
+    /**
+     * Card wrapper.
+     * @param {string} icon - Font Awesome icon class
+     * @param {string} title - Card title
+     * @param {string} body - Card body markup
+     * @returns {string} HTML
+     */
+    _card(icon, title, body) {
+        return `
+            <div style="background:rgba(0,0,0,0.15);border:1px solid rgba(255,255,255,0.08);
+                        border-radius:8px;padding:18px;">
+                <div style="display:flex;align-items:center;gap:9px;margin-bottom:14px;
+                            font-weight:600;color:#e0e0e0;">
+                    <i class="fa-solid ${icon}" style="color:#4a9eff;"></i>${title}
+                </div>
+                ${body}
+            </div>`;
+    }
+
+    /**
+     * A labelled radio group.
+     * @param {string} title - Group title
+     * @param {Array<object>} options - Radio option descriptors
+     * @returns {string} HTML
+     */
+    _choice(title, options) {
+        const radios = options.map(o => `
+            <label style="display:flex;align-items:flex-start;gap:9px;cursor:pointer;">
+                <input type="radio" ${o.checked ? "checked" : ""} onchange="${o.on}"
+                       style="margin-top:3px;">
+                <span>
+                    ${o.label}
+                    <span style="display:block;color:#8d8d8d;font-size:0.85em;margin-top:2px;">
+                        ${o.hint}
+                    </span>
+                </span>
+            </label>`).join("");
+
+        return `
+            <div style="margin-top:16px;">
+                <div style="color:#bbb;font-size:0.85em;text-transform:uppercase;
+                            letter-spacing:0.04em;margin-bottom:8px;">${title}</div>
+                <div style="display:flex;flex-direction:column;gap:10px;font-size:0.9em;">
+                    ${radios}
+                </div>
+            </div>`;
+    }
+
+    /**
+     * Amber warning box.
+     * @param {string} html - Warning body
+     * @returns {string} HTML
+     */
+    _warning(html) {
+        return `
+            <div style="margin-top:14px;background:rgba(255,193,7,0.1);
+                        border-left:3px solid #ffc107;border-radius:4px;padding:11px 13px;
+                        font-size:0.87em;color:#ddd;line-height:1.5;">
+                <i class="fas fa-exclamation-triangle"
+                   style="color:#ffc107;margin-right:7px;"></i>${html}
+            </div>`;
+    }
+
+    /**
+     * A label/value row.
+     * @param {string} label - Row label
+     * @param {string} value - Row value markup
+     * @returns {string} HTML
+     */
+    _metaRow(label, value) {
+        return `
+            <div style="display:flex;justify-content:space-between;gap:14px;">
+                <span style="color:#9d9d9d;">${label}</span>
+                <span style="text-align:right;">${value}</span>
+            </div>`;
+    }
+
+    /**
+     * Centred spinner.
+     * @param {string} text - Loading message
+     * @returns {string} HTML
+     */
+    _loading(text) {
+        return `
+            <div style="display:flex;justify-content:center;align-items:center;height:100%;
+                        color:#888;">
+                <i class="fas fa-spinner fa-spin" style="font-size:1.6em;margin-right:12px;"></i>
+                ${text}
+            </div>`;
+    }
+
+    /**
+     * Centred error block.
+     * @param {string} title - Headline
+     * @param {string} detail - Detail line
+     * @returns {string} HTML
+     */
+    _error(title, detail) {
+        return `
+            <div style="text-align:center;color:#dc3545;padding:40px 20px;">
+                <i class="fas fa-exclamation-triangle" style="font-size:1.8em;"></i>
+                <div style="margin-top:12px;color:#e0e0e0;">${this._escape(title)}</div>
+                <div style="margin-top:6px;color:#999;font-size:0.85em;">
+                    ${this._escape(String(detail))}
+                </div>
+            </div>`;
+    }
+
+    /**
+     * Date portion of an ISO timestamp.
+     * @param {string} iso - ISO timestamp
+     * @returns {string} YYYY-MM-DD
+     */
+    _day(iso) {
+        return String(iso || "").slice(0, 10);
+    }
+
+    /**
+     * Escape text for interpolation into markup.
+     * @param {string} text - Raw text
+     * @returns {string} Escaped text
+     */
+    _escape(text) {
+        const div = document.createElement("div");
+        div.textContent = text === null || text === undefined ? "" : String(text);
+        return div.innerHTML;
+    }
+
+    /**
+     * Show a toast, reusing the configuration panel's implementation.
+     * @param {string} message - Toast text
+     * @param {string} type - info | success | warning | error
+     * @param {number} duration - Milliseconds on screen
+     */
+    _toast(message, type = "info", duration = 3500) {
+        if (typeof configurationManager === "undefined") {
+            return;
+        }
+        if (!configurationManager) {
+            configurationManager = new ConfigurationManager();
+        }
+        configurationManager._showToast(message, type, duration);
+    }
+}
+
+let backupManager;
+
+/**
+ * Open the Backup & Restore panel from the main menu.
+ */
+function showBackupMenu() {
+    if (!backupManager) {
+        backupManager = new BackupManager();
+    }
+    backupManager.showBackupMenu();
+}

--- a/src/web/js/backup.js
+++ b/src/web/js/backup.js
@@ -97,11 +97,21 @@ class BackupManager {
      * Render the whole panel from current state.
      */
     _render() {
+        // Mid-restore the backup card is just noise, and leaving it on screen pushed the
+        // Confirm button below the fold. Show one thing at a time.
+        const cards = this.preview || this.result
+            ? this._restoreCard()
+            : `${this._backupCard()}${this._restoreCard()}`;
+
         this._renderInto(`
             <div style="max-width:820px;margin:0 auto;display:flex;flex-direction:column;gap:18px;">
-                ${this._backupCard()}
-                ${this._restoreCard()}
+                ${cards}
             </div>`);
+
+        const content = document.getElementById("full_screen_content");
+        if (content) {
+            content.scrollTop = 0;
+        }
     }
 
     /**
@@ -115,26 +125,15 @@ class BackupManager {
             ? `${this._day(history.oldest)} → ${this._day(history.newest)}`
             : "nothing recorded yet";
 
-        const counts = [
-            `<div style="display:flex;justify-content:space-between;gap:12px;">
-                <span><i class="fa-solid fa-gear" style="width:18px;color:#888;"></i>
-                Configuration</span>
-                <span style="color:#bbb;">${settings.count || 0} settings</span>
-            </div>`,
-            `<div style="display:flex;justify-content:space-between;gap:12px;">
-                <span><i class="fa-solid fa-solar-panel" style="width:18px;color:#888;"></i>
-                PV yield history</span>
-                <span style="color:#bbb;">${history.available === false
-                    ? "unavailable"
-                    : `${history.count || 0} hours · ${this._escape(span)}`}</span>
-            </div>`,
-        ].join("");
+        const details = {
+            settings: `${settings.count || 0} settings`,
+            pv_yield_history: history.available === false
+                ? "unavailable"
+                : `${history.count || 0} hours · ${this._escape(span)}`,
+        };
 
         return this._card("fa-download", "Create a backup", `
-            <div style="display:flex;flex-direction:column;gap:8px;font-size:0.92em;">
-                ${counts}
-            </div>
-            ${this._datasetPicker("backup")}
+            ${this._datasetPicker("backup", details)}
             ${this._warning(`
                 The backup file contains your access tokens and inverter password in
                 <strong>plain text</strong>. It has to — a masked file could not restore.
@@ -189,38 +188,54 @@ class BackupManager {
         rows.push(this._metaRow("Written", p.exported_at
             ? this._escape(this._day(p.exported_at))
             : "<span style='color:#ffc107;'>unknown — older config export</span>"));
-
-        if (settings) {
-            rows.push(this._metaRow("Settings to write", `${settings.imported}
-                (${settings.changed} changed)`));
-            if (settings.removed.length) {
-                rows.push(this._metaRow(
-                    "Settings to remove",
-                    `<span style="color:#ffc107;">${settings.removed.length}</span>`
-                ));
-            }
-            if (settings.invalid.length) {
-                rows.push(this._metaRow(
-                    "Values rejected",
-                    `<span style="color:#ffc107;">${settings.invalid.length} — skipped</span>`
-                ));
-            }
+        if (settings && settings.invalid.length) {
+            rows.push(this._metaRow(
+                "Values rejected",
+                `<span style="color:#ffc107;">${settings.invalid.length} — skipped</span>`
+            ));
         }
         if (history && history.available !== false) {
-            rows.push(this._metaRow("Yield hours in file", `${history.total || 0}`));
             if (history.skipped) {
                 rows.push(this._metaRow(
                     "Yield rows unusable",
                     `<span style="color:#ffc107;">${history.skipped} — skipped</span>`
                 ));
             }
+            // Without these two the dataset line reads "2 of 6 hours" with no
+            // explanation of where the other four went.
+            if (history.collisions) {
+                rows.push(this._metaRow(
+                    "Hours already measured here",
+                    `${history.collisions} — will be left untouched`
+                ));
+            }
+            if (history.dropped_old) {
+                rows.push(this._metaRow(
+                    "Hours too old to keep",
+                    `${history.dropped_old} — will not be written`
+                ));
+            }
+        }
+
+        // What each dataset would actually do, shown against its own checkbox rather
+        // than as a second list repeating the same two labels.
+        const details = {};
+        if (settings) {
+            details.settings = `${settings.imported} to write, ${settings.changed} changed`
+                + (settings.removed.length
+                    ? `, <span style="color:#ffc107;">${settings.removed.length} removed</span>`
+                    : "");
+        }
+        if (history && history.available !== false) {
+            details.pv_yield_history = `${history.valid || 0} of ${history.total || 0} hours`;
         }
 
         return `
-            <div style="display:flex;flex-direction:column;gap:6px;font-size:0.9em;">
+            <div style="display:flex;flex-direction:column;gap:6px;font-size:0.9em;
+                        margin-bottom:16px;">
                 ${rows.join("")}
             </div>
-            ${this._datasetPicker("restore")}
+            ${this._datasetPicker("restore", details)}
             ${this._modePicker()}
             ${this._historyPicker()}
             ${this._removalWarning()}
@@ -318,35 +333,41 @@ class BackupManager {
     // ── Pickers ─────────────────────────────────────────────────
 
     /**
-     * Dataset checkboxes.
-     * @param {string} scope - "backup" or "restore", used only for input ids
+     * Dataset checkboxes, each with what it currently amounts to.
+     * @param {string} scope - "backup" or "restore"; selects which selection it drives
+     * @param {object} details - Per-dataset right-hand summary, keyed by dataset key
      * @returns {string} HTML
      */
-    _datasetPicker(scope) {
+    _datasetPicker(scope, details = {}) {
         const selection = scope === "backup" ? this.forBackup : this.forRestore;
         const items = BACKUP_DATASETS.map(ds => {
             const unavailable = ds.key === "pv_yield_history"
                 && this.info && this.info.pv_yield_history
                 && this.info.pv_yield_history.available === false;
+            const detail = details[ds.key];
             return `
-                <label style="display:flex;align-items:flex-start;gap:9px;cursor:${
+                <label for="ds-${scope}-${ds.key}"
+                       style="display:flex;align-items:flex-start;gap:9px;cursor:${
                     unavailable ? "not-allowed" : "pointer"};opacity:${unavailable ? "0.5" : "1"};">
                     <input type="checkbox" id="ds-${scope}-${ds.key}"
                            ${selection[ds.key] && !unavailable ? "checked" : ""}
                            ${unavailable ? "disabled" : ""}
                            onchange="backupManager._toggle('${scope}', '${ds.key}', this.checked)"
                            style="margin-top:3px;">
-                    <span>
+                    <span style="flex:1;">
                         <i class="fa-solid ${ds.icon}" style="width:18px;color:#888;"></i>
                         ${ds.label}
                         <span style="display:block;margin-left:26px;color:#8d8d8d;font-size:0.82em;">
                             ${ds.hint}
                         </span>
                     </span>
+                    ${detail
+                        ? `<span style="color:#bbb;white-space:nowrap;">${detail}</span>`
+                        : ""}
                 </label>`;
         }).join("");
 
-        return `<div style="margin-top:14px;display:flex;flex-direction:column;gap:10px;
+        return `<div style="display:flex;flex-direction:column;gap:12px;
                             font-size:0.9em;">${items}</div>`;
     }
 
@@ -360,6 +381,8 @@ class BackupManager {
         }
         return this._choice("How to restore the configuration", [
             {
+                id: "backup-mode-replace",
+                group: "backup-mode",
                 value: "replace",
                 checked: this.mode === "replace",
                 label: "Replace",
@@ -368,6 +391,8 @@ class BackupManager {
                 on: "backupManager._setMode('replace')",
             },
             {
+                id: "backup-mode-merge",
+                group: "backup-mode",
                 value: "merge",
                 checked: this.mode === "merge",
                 label: "Merge",
@@ -401,6 +426,8 @@ class BackupManager {
 
         return this._choice("How to restore the measured history", [
             {
+                id: "backup-history-as-is",
+                group: "backup-history-mode",
                 value: "as_is",
                 checked: this.historyMode === "as_is",
                 label: "Keep original dates",
@@ -408,6 +435,8 @@ class BackupManager {
                 on: "backupManager._setHistoryMode('as_is')",
             },
             {
+                id: "backup-history-seed",
+                group: "backup-history-mode",
                 value: "seed",
                 checked: this.historyMode === "seed",
                 label: `Shift into the current window${stale ? " — recommended" : ""}`,
@@ -706,14 +735,19 @@ class BackupManager {
 
     /**
      * A labelled radio group.
+     *
+     * Each option carries an explicit `id` and shared `group` name so the label is
+     * properly associated with its input rather than relying on nesting alone.
      * @param {string} title - Group title
-     * @param {Array<object>} options - Radio option descriptors
+     * @param {Array<object>} options - Radio option descriptors: id, group, checked,
+     *     label, hint, on
      * @returns {string} HTML
      */
     _choice(title, options) {
         const radios = options.map(o => `
-            <label style="display:flex;align-items:flex-start;gap:9px;cursor:pointer;">
-                <input type="radio" ${o.checked ? "checked" : ""} onchange="${o.on}"
+            <label for="${o.id}" style="display:flex;align-items:flex-start;gap:9px;cursor:pointer;">
+                <input type="radio" id="${o.id}" name="${o.group}"
+                       ${o.checked ? "checked" : ""} onchange="${o.on}"
                        style="margin-top:3px;">
                 <span>
                     ${o.label}

--- a/src/web/js/backup.js
+++ b/src/web/js/backup.js
@@ -9,6 +9,10 @@
  * overwrite a working configuration, which is not something to discover afterwards.
  */
 
+// Narrowest a column may get before the grid drops to a single column. Matches the
+// auto-fit minmax() widths used by the statistics and logging overlays.
+const GRID_MIN = "330px";
+
 const BACKUP_DATASETS = [
     {
         key: "settings",
@@ -99,19 +103,62 @@ class BackupManager {
     _render() {
         // Mid-restore the backup card is just noise, and leaving it on screen pushed the
         // Confirm button below the fold. Show one thing at a time.
-        const cards = this.preview || this.result
-            ? this._restoreCard()
-            : `${this._backupCard()}${this._restoreCard()}`;
+        const busy = this.preview || this.result;
 
-        this._renderInto(`
-            <div style="max-width:820px;margin:0 auto;display:flex;flex-direction:column;gap:18px;">
-                ${cards}
-            </div>`);
+        // Two independent actions sit side by side where there is room and stack where
+        // there is not, matching the auto-fit grids the other overlays use. A restore in
+        // progress takes the full width instead — it has the most to say.
+        const body = busy
+            ? this._restoreCard()
+            : `<div style="display:grid;
+                          grid-template-columns:repeat(auto-fit, minmax(${GRID_MIN}, 1fr));
+                          gap:15px;">
+                   ${this._backupCard()}
+                   ${this._restoreCard()}
+               </div>`;
+
+        this._renderInto(`${body}${busy ? "" : this._explainer()}`);
 
         const content = document.getElementById("full_screen_content");
         if (content) {
             content.scrollTop = 0;
         }
+    }
+
+    /**
+     * Closing prose, in the same place and style as the other overlays' "How it works".
+     *
+     * Also stops the panel from being two short cards above a large empty area on a
+     * desktop screen, which is what it looked like before.
+     * @returns {string} HTML
+     */
+    _explainer() {
+        const days = (this.info && this.info.retention_days) || 7;
+        return `
+            <div style="padding:15px 5px;color:#aaa;font-size:0.88em;line-height:1.6;">
+                <div style="font-weight:bold;color:#ccc;margin-bottom:10px;">How it works:</div>
+                <p style="margin:0 0 10px;">
+                    A backup holds everything this install keeps: every configuration
+                    setting, and the hourly record of measured PV yield against forecast
+                    that <strong>PV Auto-Scaling</strong> derives its correction factors
+                    from. That measured history is stored nowhere else and is deleted on a
+                    rolling ${days}-day window, so a backup is the only way to keep it.
+                </p>
+                <p style="margin:0 0 10px;">
+                    <strong>Restoring never applies straight away.</strong> The file is
+                    inspected first and you are shown what would change — including any
+                    settings that would be removed — before anything is written. Settings
+                    that can be applied live take effect immediately; the rest raise the
+                    usual restart banner.
+                </p>
+                <p style="margin:0;">
+                    A backup older than the retention window can have its history
+                    <strong>shifted into the current window</strong>, keeping each hour's
+                    measured-to-forecast ratio so scaling works from the first run instead
+                    of after days of re-learning. Those rows are marked as seeded, never
+                    passed off as measured here.
+                </p>
+            </div>`;
     }
 
     /**
@@ -146,7 +193,7 @@ class BackupManager {
                     <i class="fas fa-download"></i> Download backup
                 </button>
             </div>
-        `);
+        `, "everything this install keeps");
     }
 
     /**
@@ -168,10 +215,11 @@ class BackupManager {
                    onchange="backupManager._pick(this.files[0])">
             <button onclick="document.getElementById('backup-restore-file').click()"
                     style="background:#5a5a5a;color:#e0e0e0;border:1px solid rgba(255,255,255,0.15);
-                           border-radius:6px;padding:9px 16px;cursor:pointer;font-size:0.9em;">
+                           border-radius:6px;padding:9px 16px;cursor:pointer;font-size:0.9em;
+                           align-self:flex-start;">
                 <i class="fas fa-folder-open"></i> Choose backup file…
             </button>
-        `);
+        `, "previewed before anything is written");
     }
 
     /**
@@ -230,14 +278,29 @@ class BackupManager {
             details.pv_yield_history = `${history.valid || 0} of ${history.total || 0} hours`;
         }
 
+        // Wide screens put "what is in the file" beside "how to restore it" instead of
+        // running one long column the user has to scroll to reach the buttons.
         return `
-            <div style="display:flex;flex-direction:column;gap:6px;font-size:0.9em;
-                        margin-bottom:16px;">
-                ${rows.join("")}
+            <div style="display:grid;
+                        grid-template-columns:repeat(auto-fit, minmax(${GRID_MIN}, 1fr));
+                        gap:15px;">
+                <div style="background-color:rgba(255,255,255,0.05);border-radius:6px;
+                            padding:12px;border-left:3px solid #4a9eff;">
+                    <div style="font-weight:600;color:#ddd;margin-bottom:10px;">
+                        What this file holds
+                    </div>
+                    <div style="display:flex;flex-direction:column;gap:6px;font-size:0.9em;
+                                margin-bottom:14px;">
+                        ${rows.join("")}
+                    </div>
+                    ${this._datasetPicker("restore", details)}
+                </div>
+                <div style="background-color:rgba(255,255,255,0.05);border-radius:6px;
+                            padding:12px;border-left:3px solid #4a9eff;">
+                    ${this._modePicker()}
+                    ${this._historyPicker()}
+                </div>
             </div>
-            ${this._datasetPicker("restore", details)}
-            ${this._modePicker()}
-            ${this._historyPicker()}
             ${this._removalWarning()}
             ${this._invalidWarning()}
             ${this._anySelectedForRestore() ? "" : this._warning(
@@ -271,35 +334,30 @@ class BackupManager {
         const lines = [];
 
         if (settings) {
-            lines.push(this._metaRow("Settings restored", `${settings.imported}`));
+            lines.push(this._tile("Settings restored", settings.imported));
             if (settings.removed.length) {
-                lines.push(this._metaRow("Settings removed", `${settings.removed.length}`));
+                lines.push(this._tile("Settings removed", settings.removed.length));
             }
             if (settings.invalid.length) {
-                lines.push(this._metaRow(
-                    "Values skipped",
-                    `<span style="color:#ffc107;">${settings.invalid.length}</span>`
-                ));
+                lines.push(this._tile("Values skipped", settings.invalid.length, "#ffc107"));
             }
         }
         if (history && history.available !== false) {
-            lines.push(this._metaRow("Yield hours restored", `${history.imported || 0}`));
+            lines.push(this._tile("Yield hours restored", history.imported || 0));
             if (history.shift_days > 0) {
-                lines.push(this._metaRow(
-                    "History shifted",
-                    `${history.shift_days} day(s) forward — marked as seeded`
+                lines.push(this._tile(
+                    "History shifted", `${history.shift_days}d`, "#ffc107",
+                    "forward — marked as seeded"
                 ));
             }
             if (history.collisions) {
-                lines.push(this._metaRow(
-                    "Hours already measured here",
-                    `${history.collisions} — left untouched`
+                lines.push(this._tile(
+                    "Hours already measured here", history.collisions, null, "left untouched"
                 ));
             }
             if (history.dropped_old) {
-                lines.push(this._metaRow(
-                    "Hours too old to keep",
-                    `${history.dropped_old} — not written`
+                lines.push(this._tile(
+                    "Hours too old to keep", history.dropped_old, null, "not written"
                 ));
             }
         }
@@ -308,7 +366,9 @@ class BackupManager {
         const outside = history ? history.outside_retention : 0;
 
         return `
-            <div style="display:flex;flex-direction:column;gap:6px;font-size:0.9em;">
+            <div style="display:grid;
+                        grid-template-columns:repeat(auto-fit, minmax(200px, 1fr));
+                        gap:10px;">
                 ${lines.join("")}
             </div>
             ${restart.length ? this._warning(`
@@ -345,6 +405,15 @@ class BackupManager {
                 && this.info && this.info.pv_yield_history
                 && this.info.pv_yield_history.available === false;
             const detail = details[ds.key];
+            // Beside the label where there is room; underneath it on a phone, where a
+            // nowrap detail column squeezes the label into a two-character ribbon.
+            const narrow = typeof isMobile === "function" && isMobile();
+            const detailHtml = detail
+                ? narrow
+                    ? `<span style="display:block;margin-left:26px;margin-top:3px;
+                                    color:#bbb;">${detail}</span>`
+                    : `<span style="color:#bbb;white-space:nowrap;">${detail}</span>`
+                : "";
             return `
                 <label for="ds-${scope}-${ds.key}"
                        style="display:flex;align-items:flex-start;gap:9px;cursor:${
@@ -354,16 +423,15 @@ class BackupManager {
                            ${unavailable ? "disabled" : ""}
                            onchange="backupManager._toggle('${scope}', '${ds.key}', this.checked)"
                            style="margin-top:3px;">
-                    <span style="flex:1;">
+                    <span style="flex:1;min-width:0;">
                         <i class="fa-solid ${ds.icon}" style="width:18px;color:#888;"></i>
                         ${ds.label}
                         <span style="display:block;margin-left:26px;color:#8d8d8d;font-size:0.82em;">
                             ${ds.hint}
                         </span>
+                        ${narrow ? detailHtml : ""}
                     </span>
-                    ${detail
-                        ? `<span style="color:#bbb;white-space:nowrap;">${detail}</span>`
-                        : ""}
+                    ${narrow ? "" : detailHtml}
                 </label>`;
         }).join("");
 
@@ -715,19 +783,25 @@ class BackupManager {
     // ── Small helpers ───────────────────────────────────────────
 
     /**
-     * Card wrapper.
+     * Section wrapper, styled like the sections in the other full-screen overlays.
      * @param {string} icon - Font Awesome icon class
-     * @param {string} title - Card title
-     * @param {string} body - Card body markup
+     * @param {string} title - Section title
+     * @param {string} body - Section body markup
+     * @param {string} note - Optional right-aligned subtitle
      * @returns {string} HTML
      */
-    _card(icon, title, body) {
+    _card(icon, title, body, note = "") {
         return `
-            <div style="background:rgba(0,0,0,0.15);border:1px solid rgba(255,255,255,0.08);
-                        border-radius:8px;padding:18px;">
-                <div style="display:flex;align-items:center;gap:9px;margin-bottom:14px;
-                            font-weight:600;color:#e0e0e0;">
-                    <i class="fa-solid ${icon}" style="color:#4a9eff;"></i>${title}
+            <div style="background-color:rgba(0,0,0,0.2);border-radius:8px;padding:15px;
+                        display:flex;flex-direction:column;">
+                <div style="display:flex;justify-content:space-between;align-items:center;
+                            gap:12px;margin-bottom:12px;">
+                    <div style="font-weight:bold;color:#ccc;">
+                        <i class="fa-solid ${icon}" style="margin-right:6px;"></i>${title}
+                    </div>
+                    ${note && !(typeof isMobile === "function" && isMobile())
+                        ? `<div style="font-size:0.85em;color:#888;text-align:right;">${note}</div>`
+                        : ""}
                 </div>
                 ${body}
             </div>`;
@@ -758,9 +832,8 @@ class BackupManager {
             </label>`).join("");
 
         return `
-            <div style="margin-top:16px;">
-                <div style="color:#bbb;font-size:0.85em;text-transform:uppercase;
-                            letter-spacing:0.04em;margin-bottom:8px;">${title}</div>
+            <div style="margin-bottom:16px;">
+                <div style="font-weight:600;color:#ddd;margin-bottom:10px;">${title}</div>
                 <div style="display:flex;flex-direction:column;gap:10px;font-size:0.9em;">
                     ${radios}
                 </div>
@@ -779,6 +852,28 @@ class BackupManager {
                         font-size:0.87em;color:#ddd;line-height:1.5;">
                 <i class="fas fa-exclamation-triangle"
                    style="color:#ffc107;margin-right:7px;"></i>${html}
+            </div>`;
+    }
+
+    /**
+     * A single count, rendered like the stat tiles in the other overlays.
+     * @param {string} label - What is being counted
+     * @param {string|number} value - The count
+     * @param {string} color - Optional accent for the value
+     * @param {string} note - Optional qualifier under the value
+     * @returns {string} HTML
+     */
+    _tile(label, value, color = null, note = "") {
+        return `
+            <div style="background-color:rgba(255,255,255,0.05);border-radius:6px;
+                        padding:12px;text-align:center;border-left:3px solid ${
+                            color || "#4a9eff"};">
+                <div style="font-size:0.85em;color:#888;margin-bottom:6px;">${label}</div>
+                <div style="font-size:1.6em;font-weight:bold;font-family:monospace;
+                            color:${color || "#4caf50"};">${value}</div>
+                ${note
+                    ? `<div style="font-size:0.78em;color:#aaa;margin-top:4px;">${note}</div>`
+                    : ""}
             </div>`;
     }
 

--- a/src/web/js/config.js
+++ b/src/web/js/config.js
@@ -210,13 +210,13 @@ class ConfigurationManager {
                     <button onclick="configurationManager._exportConfig()"
                             class="config-btn config-btn-secondary config-header-tool"
                             style="padding:5px 10px;font-size:0.8em;"
-                            title="Export Configuration">
+                            title="Export configuration only — for a full backup including measured PV history, use Menu ▸ Backup &amp; Restore">
                         <i class="fas fa-download"></i>
                     </button>
                     <button onclick="document.getElementById('cfg-import-file').click()"
                             class="config-btn config-btn-secondary config-header-tool"
                             style="padding:5px 10px;font-size:0.8em;"
-                            title="Import Configuration">
+                            title="Import configuration only — for a full restore, use Menu ▸ Backup &amp; Restore">
                         <i class="fas fa-upload"></i>
                     </button>
                     <input type="file" id="cfg-import-file" accept=".json"
@@ -920,12 +920,12 @@ class ConfigurationManager {
             </button>
             <button class="config-btn config-btn-secondary config-actions-tool"
                     onclick="configurationManager._exportConfig()"
-                    title="Export Configuration">
+                    title="Export configuration only — for a full backup including measured PV history, use Menu ▸ Backup &amp; Restore">
                 <i class="fas fa-download"></i>
             </button>
             <button class="config-btn config-btn-secondary config-actions-tool"
                     onclick="document.getElementById('cfg-import-file').click()"
-                    title="Import Configuration">
+                    title="Import configuration only — for a full restore, use Menu ▸ Backup &amp; Restore">
                 <i class="fas fa-upload"></i>
             </button>
         </div>`;
@@ -1360,7 +1360,10 @@ class ConfigurationManager {
     // ── Import / Export ─────────────────────────────────────────
 
     /**
-     * Export the full configuration as a downloadable JSON file.
+     * Export the configuration as a downloadable JSON file.
+     *
+     * Configuration only. The measured PV yield history lives in the same database but
+     * is not part of this file — Menu ▸ Backup & Restore covers the whole install.
      */
     async _exportConfig() {
         try {
@@ -1379,7 +1382,12 @@ class ConfigurationManager {
             a.click();
             document.body.removeChild(a);
             URL.revokeObjectURL(url);
-            this._showToast("Configuration exported.", "success");
+            this._showToast(
+                "Configuration exported. For a full backup including measured PV "
+                + "history, use Menu ▸ Backup & Restore.",
+                "success",
+                6000
+            );
         } catch (err) {
             this._showToast("Export failed: " + (err.message || err), "error");
         }
@@ -1387,6 +1395,9 @@ class ConfigurationManager {
 
     /**
      * Import configuration from a JSON file.
+     *
+     * Configuration only. A full backup dropped here restores its settings and leaves
+     * the measured PV history alone; the toast says so rather than ignoring it quietly.
      * @param {File} file - The selected JSON file
      */
     async _importConfig(file) {
@@ -1416,15 +1427,37 @@ class ConfigurationManager {
 
             const count = result.imported || 0;
             const skipped = result.skipped || 0;
+            const invalid = (result.invalid || []).length;
+            const restart = result.restart_required || [];
+            const ignored = result.ignored_datasets || [];
+
             let msg = `Imported ${count} setting(s).`;
             if (skipped > 0) {
                 msg += ` Skipped ${skipped} unknown key(s).`;
+            }
+            if (invalid > 0) {
+                msg += ` Skipped ${invalid} value(s) that are no longer valid.`;
+            }
+            if (restart.length > 0) {
+                msg += ` Restart required for ${restart.length} field(s).`;
+                this.restartFields = [...new Set([...this.restartFields, ...restart])];
             }
 
             // Reload data to reflect imported values
             await this._loadData();
             this._selectSection(this.currentSection || this._orderedSections()[0]);
-            this._showToast(msg, "success");
+            this._showToast(msg, invalid > 0 || restart.length > 0 ? "warning" : "success");
+
+            if (ignored.length > 0) {
+                // This is a full backup, not a config export. Say what was left behind
+                // instead of silently dropping it.
+                this._showToast(
+                    "This file also contains measured PV yield history, which was not "
+                    + "restored. Use Menu ▸ Backup & Restore to restore it.",
+                    "info",
+                    9000
+                );
+            }
         } catch (err) {
             this._showToast("Import failed: " + (err.message || err), "error");
         }

--- a/src/web/js/statistics.js
+++ b/src/web/js/statistics.js
@@ -391,11 +391,23 @@ class StatisticsManager {
                     const actual = day.actual_kwh || {};
                     const forecast = day.forecast_kwh || {};
                     const hours = day.hours_collected || 0;
+                    // Days restored from a backup are not measurements from this
+                    // system; label them so a seeded scale factor is never mistaken
+                    // for one this install learnt.
+                    const restored = day.origin && day.origin !== 'measured';
+                    const originBadge = restored
+                        ? `<span title="Restored from a backup${day.origin === 'seeded'
+                            ? ', with its dates shifted into the current window'
+                            : ''} - not measured on this system"
+                                 style="font-size: 0.7em; color: #ffc107; border: 1px solid rgba(255,193,7,0.5); border-radius: 3px; padding: 1px 5px; margin-left: 6px;">
+                            <i class="fa-solid fa-box-archive"></i> ${day.origin}
+                           </span>`
+                        : '';
 
                     historicalHtml += `
-                        <div style="background-color: rgba(255,255,255,0.05); border-radius: 6px; padding: 10px; border-left: 3px solid #4a9eff;">
+                        <div style="background-color: rgba(255,255,255,0.05); border-radius: 6px; padding: 10px; border-left: 3px solid ${restored ? '#ffc107' : '#4a9eff'};">
                             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
-                                <span style="font-weight: 600; color: #ddd;">${dateStr}</span>
+                                <span style="font-weight: 600; color: #ddd;">${dateStr}${originBadge}</span>
                                 <span style="font-size: 0.8em; color: #888;">${hours} hours recorded</span>
                             </div>
                             <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; font-size: 0.8em;">
@@ -428,6 +440,9 @@ class StatisticsManager {
                             </div>
                             <div style="font-size: 0.8em; color: #888; margin-top: 10px;">
                                 <strong>Legend:</strong> R = Real yield | F = Forecast
+                                ${(pa.restored_hours || 0) > 0
+                                    ? ` | <span style="color: #ffc107;"><i class="fa-solid fa-box-archive"></i> ${pa.restored_hours} hour(s) restored from a backup, not measured here</span>`
+                                    : ''}
                             </div>
                         </div>
                     `;

--- a/src/web/js/ui.js
+++ b/src/web/js/ui.js
@@ -212,6 +212,13 @@ function showMainMenu(version, backend, granularity) {
             <i class="fa-solid fa-gear" style="margin-right: 10px; color: #cccccc; width: 16px;"></i>
             <span>Configuration</span>
         </div>
+
+        <div onclick="showBackupMenu(); closeDropdownMenu();" style="cursor: pointer; padding: 10px 15px; transition: background-color 0.2s; display: flex; align-items: center;"
+            onmouseover="this.style.backgroundColor='rgba(100, 100, 100, 0.5)'"
+            onmouseout="this.style.backgroundColor='transparent'">
+            <i class="fa-solid fa-box-archive" style="margin-right: 10px; color: #cccccc; width: 16px;"></i>
+            <span>Backup &amp; Restore</span>
+        </div>
         
         <hr style="border: none; border-top: 1px solid rgba(255, 255, 255, 0.1); margin: 5px 0;">
 

--- a/tests/config_web/test_api.py
+++ b/tests/config_web/test_api.py
@@ -71,6 +71,7 @@ class _FakeModule:
         self._config = config
         self._store = store
         self._schema = schema
+        self.notified = []
 
     def get_config(self):
         """Return current merged config."""
@@ -78,6 +79,10 @@ class _FakeModule:
 
     def rebuild_config(self):
         """No-op for tests."""
+
+    def notify_config_changed(self, key, old_value, new_value):
+        """Record hot-reload notifications so tests can assert they were fired."""
+        self.notified.append((key, old_value, new_value))
 
 
 @pytest.fixture
@@ -98,6 +103,10 @@ def client(tmp_path):
     app.register_blueprint(config_bp)
 
     with app.test_client() as c:
+        # Handed to tests that need to inspect what the API did to the store or
+        # which hot-reload notifications it fired.
+        c.store = store
+        c.module = module
         yield c
 
     store.close()
@@ -646,3 +655,208 @@ class TestWizardAPI:
         resp = fresh_client.post("/api/config/wizard-complete")
         assert resp.status_code == 200
         assert resp.get_json()["completed"] is True
+
+
+class TestImportAppliesChanges:
+    """
+    Import must behave like a save, not a raw database write.
+
+    ``ConfigStore.import_dict`` wrote straight to SQL, so an imported config never
+    reached the running interfaces and never raised the restart banner.  These pin the
+    behaviour that replaced it.
+    """
+
+    def test_import_fires_hot_reload_notifications(self, client):
+        """Imported values must be replayed to the hot-reload callbacks."""
+        client.module.notified.clear()
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps({"price.feed_in_price": 0.42}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+
+        notified = dict((k, v) for k, _o, v in client.module.notified)
+        assert notified.get("price.feed_in_price") == 0.42
+
+    def test_import_skips_notification_for_unchanged_values(self, client):
+        """A key already holding the imported value must not trigger a reload."""
+        client.post(
+            "/api/config/import",
+            data=json.dumps({"price.feed_in_price": 0.42}),
+            content_type="application/json",
+        )
+        client.module.notified.clear()
+        client.post(
+            "/api/config/import",
+            data=json.dumps({"price.feed_in_price": 0.42}),
+            content_type="application/json",
+        )
+        assert [k for k, _o, _n in client.module.notified] == []
+
+    def test_import_records_restart_pending(self, client):
+        """A restart_required field must raise the banner that survives a reload."""
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps({"eos_connect_web_port": 8099}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert "eos_connect_web_port" in resp.get_json()["restart_required"]
+
+        resp2 = client.get("/api/config/restart-required")
+        assert "eos_connect_web_port" in resp2.get_json()["fields"]
+
+    def test_import_reports_hot_reloaded_fields(self, client):
+        """Hot-reloadable fields are reported separately from restart-required ones."""
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps({"price.feed_in_price": 0.11}),
+            content_type="application/json",
+        )
+        data = resp.get_json()
+        assert "price.feed_in_price" in data["hot_reloaded"]
+        assert data["restart_required"] == []
+
+    def test_import_skips_invalid_values_without_aborting(self, client):
+        """An out-of-range value is reported and skipped; the rest still imports."""
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps(
+                {"battery.min_soc_percentage": 9999, "battery.capacity_wh": 15000}
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported"] == 1
+        assert [e["key"] for e in data["invalid"]] == ["battery.min_soc_percentage"]
+
+        exported = client.get("/api/config/export").get_json()
+        assert exported["battery.capacity_wh"] == 15000
+        assert exported["battery.min_soc_percentage"] != 9999
+
+    def test_import_does_not_count_metadata_as_skipped(self, client):
+        """Backup metadata is not a setting and not an unknown key either."""
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps(
+                {
+                    "_format": "eos-connect-backup",
+                    "_version": 1,
+                    "battery.capacity_wh": 12345,
+                }
+            ),
+            content_type="application/json",
+        )
+        data = resp.get_json()
+        assert data["imported"] == 1
+        assert data["skipped"] == 0
+
+    def test_import_still_counts_unknown_keys(self, client):
+        """Genuinely unrecognised keys remain reported as skipped."""
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps({"there.is.no.such.key": 1, "battery.capacity_wh": 11000}),
+            content_type="application/json",
+        )
+        data = resp.get_json()
+        assert data["imported"] == 1
+        assert data["skipped"] == 1
+
+    def test_config_import_reports_but_ignores_yield_history(self, client):
+        """A full backup dropped here restores settings and names what it left alone."""
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps(
+                {
+                    "_format": "eos-connect-backup",
+                    "battery.capacity_wh": 17000,
+                    "pv_yield_history": [{"timestamp": "2026-08-19T06:00:00+00:00"}],
+                }
+            ),
+            content_type="application/json",
+        )
+        data = resp.get_json()
+        assert data["imported"] == 1
+        assert data["skipped"] == 0
+        assert data["ignored_datasets"] == ["pv_yield_history"]
+
+    def test_config_import_is_merge_only(self, client):
+        """The config-scoped endpoint never removes settings absent from the file."""
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps({"battery.capacity_wh": 16000}),
+            content_type="application/json",
+        )
+        assert resp.get_json()["removed"] == []
+        exported = client.get("/api/config/export").get_json()
+        assert exported["eos.port"] == 8503
+
+
+class TestApplySettingsReplaceMode:
+    """Replace mode is the exact inverse of export — no more, no less."""
+
+    def _apply(self, client, data, mode):
+        from src.config_web.api import apply_settings
+
+        with client.application.test_request_context():
+            return apply_settings(data, mode=mode)
+
+    def test_replace_removes_stale_keys(self, client):
+        """Settings absent from the file are removed, not left behind."""
+        exported = client.get("/api/config/export").get_json()
+        assert "eos.port" in exported
+
+        payload = {k: v for k, v in exported.items() if k != "eos.port"}
+        result = self._apply(client, payload, "replace")
+
+        assert "eos.port" in result["removed"]
+        assert "eos.port" not in client.get("/api/config/export").get_json()
+
+    def test_replace_preserves_internal_keys(self, client):
+        """Wiping _wizard_completed would pop the setup wizard after every restore."""
+        client.post("/api/config/wizard-complete")
+        assert client.get("/api/config/wizard-status").get_json()["completed"] is True
+
+        self._apply(client, {"battery.capacity_wh": 20000}, "replace")
+
+        assert client.get("/api/config/wizard-status").get_json()["completed"] is True
+
+    def test_replace_leaves_unschemad_keys_alone(self, client):
+        """The raw pv_forecast list is a merger fallback, not a stale setting."""
+        client.store.set("pv_forecast", [{"name": "legacy"}])
+        self._apply(client, {"battery.capacity_wh": 20000}, "replace")
+        assert client.store.has_key("pv_forecast")
+
+    def test_replace_drops_surplus_pv_installations(self, client):
+        """Restoring a one-installation backup must remove the second installation."""
+        client.store.set("pv_forecast.1.name", "second")
+        exported = client.get("/api/config/export").get_json()
+        assert "pv_forecast.1.name" in exported
+
+        payload = {k: v for k, v in exported.items() if not k.startswith("pv_forecast.1.")}
+        result = self._apply(client, payload, "replace")
+
+        assert "pv_forecast.1.name" in result["removed"]
+
+    def test_replace_notifies_removed_keys_with_default(self, client):
+        """A removed key reverts to its schema default; interfaces must be told."""
+        exported = client.get("/api/config/export").get_json()
+        payload = {k: v for k, v in exported.items() if k != "price.feed_in_price"}
+
+        client.module.notified.clear()
+        self._apply(client, payload, "replace")
+
+        notified = dict((k, v) for k, _o, v in client.module.notified)
+        assert "price.feed_in_price" in notified
+        assert notified["price.feed_in_price"] == 0.0
+
+    def test_replace_round_trip_is_stable(self, client):
+        """Exporting and replacing with the same file must change nothing."""
+        exported = client.get("/api/config/export").get_json()
+        result = self._apply(client, exported, "replace")
+
+        assert result["removed"] == []
+        assert result["invalid"] == []
+        assert client.get("/api/config/export").get_json() == exported

--- a/tests/config_web/test_api.py
+++ b/tests/config_web/test_api.py
@@ -755,7 +755,26 @@ class TestImportAppliesChanges:
         data = resp.get_json()
         assert data["imported"] == 1
         assert [e["key"] for e in data["invalid"]] == ["price.feed_in_price"]
-        assert "Invalid type" in data["invalid"][0]["error"]
+        assert data["invalid"][0]["error"] == "Expected a number"
+
+    def test_import_does_not_echo_exception_text(self, client):
+        """
+        The rejection message must not carry the exception's own text.
+
+        float("...") puts the offending value into its message, and returning that in an
+        HTTP response is information exposure through an exception (CodeQL). The detail
+        belongs in the log; the response gets a stable, actionable message.
+        """
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps({"price.feed_in_price": "sekrit-looking-value"}),
+            content_type="application/json",
+        )
+
+        body = resp.get_data(as_text=True)
+        assert "could not convert" not in body
+        assert "sekrit-looking-value" not in body
+        assert resp.get_json()["invalid"][0]["error"] == "Expected a number"
 
     def test_import_does_not_count_metadata_as_skipped(self, client):
         """Backup metadata is not a setting and not an unknown key either."""

--- a/tests/config_web/test_api.py
+++ b/tests/config_web/test_api.py
@@ -85,8 +85,8 @@ class _FakeModule:
         self.notified.append((key, old_value, new_value))
 
 
-@pytest.fixture
-def client(tmp_path):
+@pytest.fixture(name="client")
+def client_fixture(tmp_path):
     """Create a Flask test client with the config blueprint."""
     app = Flask(__name__)
     app.config["TESTING"] = True
@@ -517,8 +517,8 @@ def test_price_fixed_24h_array_zero_and_negative(client):
     assert resp.status_code == 200, "Should accept zero and negative numeric values"
 
 
-@pytest.fixture
-def fresh_client(tmp_path):
+@pytest.fixture(name="fresh_client")
+def fresh_client_fixture(tmp_path):
     """Create a Flask test client with NO migration (fresh install)."""
     app = Flask(__name__)
     app.config["TESTING"] = True
@@ -735,6 +735,27 @@ class TestImportAppliesChanges:
         exported = client.get("/api/config/export").get_json()
         assert exported["battery.capacity_wh"] == 15000
         assert exported["battery.min_soc_percentage"] != 9999
+
+    def test_import_reports_a_value_that_cannot_be_coerced(self, client):
+        """
+        Validation and coercion are separate gates, and both must be survivable.
+
+        A field with no validation rules skips the range checks entirely, so a value of
+        the wrong shape only fails later when it is coerced to the column's type. That
+        must be reported like any other rejected value, not raise a 500.
+        """
+        resp = client.post(
+            "/api/config/import",
+            data=json.dumps(
+                {"price.feed_in_price": "not a number", "battery.capacity_wh": 14000}
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["imported"] == 1
+        assert [e["key"] for e in data["invalid"]] == ["price.feed_in_price"]
+        assert "Invalid type" in data["invalid"][0]["error"]
 
     def test_import_does_not_count_metadata_as_skipped(self, client):
         """Backup metadata is not a setting and not an unknown key either."""

--- a/tests/config_web/test_backup.py
+++ b/tests/config_web/test_backup.py
@@ -325,6 +325,25 @@ class TestBackupRestore:
         assert result["pv_yield_history"]["present_in_file"] == 1
         assert storeless_client.store.get("battery.capacity_wh") == 12000
 
+    def test_restore_does_not_echo_exception_text(self, client):
+        """
+        The second sink CodeQL reported: the same rejection path reaches this endpoint.
+
+        Both import endpoints share apply_settings, so both would have echoed the
+        coercion exception. Guarded here as well as on /api/config/import.
+        """
+        backup = client.get("/api/backup/export").get_json()
+        backup["price.feed_in_price"] = "sekrit-looking-value"
+
+        resp = _post(client, backup)
+
+        body = resp.get_data(as_text=True)
+        assert "could not convert" not in body
+        assert "sekrit-looking-value" not in body
+        invalid = resp.get_json()["settings"]["invalid"]
+        assert [e["key"] for e in invalid] == ["price.feed_in_price"]
+        assert invalid[0]["error"] == "Expected a number"
+
     def test_restore_rejects_a_non_object_body(self, client):
         """A JSON array is not a backup."""
         resp = client.post(

--- a/tests/config_web/test_backup.py
+++ b/tests/config_web/test_backup.py
@@ -166,6 +166,15 @@ class TestBackupExport:
         assert only_settings["battery.capacity_wh"] == 10000
         assert "pv_yield_history" not in only_settings
 
+    def test_empty_include_selects_nothing(self, client):
+        """`?include=` must not collapse into "everything" — the UI sends it verbatim."""
+        _seed_hours(client)
+        data = client.get("/api/backup/export?include=").get_json()
+
+        assert data["_datasets"] == []
+        assert "battery.capacity_wh" not in data
+        assert "pv_yield_history" not in data
+
     def test_export_matches_the_config_endpoint_for_settings(self, client):
         """Both files must carry exactly the same settings."""
         backup = client.get("/api/backup/export").get_json()
@@ -268,6 +277,17 @@ class TestBackupRestore:
         _post(client, backup, "?include=pv_yield_history")
 
         assert len(client.module.pv_yield_store.get_all_history()) == 2
+        assert client.store.get("battery.capacity_wh") == 99999
+
+    def test_empty_include_restores_nothing(self, client):
+        """Deselecting every dataset must not silently restore all of them."""
+        backup = client.get("/api/backup/export").get_json()
+        client.store.set("battery.capacity_wh", 99999)
+
+        result = _post(client, backup, "?include=").get_json()
+
+        assert result["datasets"] == []
+        assert "settings" not in result
         assert client.store.get("battery.capacity_wh") == 99999
 
     def test_restore_degrades_without_a_yield_store(self, storeless_client):

--- a/tests/config_web/test_backup.py
+++ b/tests/config_web/test_backup.py
@@ -1,0 +1,330 @@
+"""
+Tests for the whole-install backup/restore endpoints.
+
+The config-scoped ``/api/config`` pair is covered in ``test_api.py``; these pin the
+behaviour that is specific to a full backup — the file's shape, dataset selection,
+the dry-run preview, and graceful degradation when there is no yield store.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+from src.config_web.api import config_bp, init_api
+from src.config_web.backup import backup_bp, init_backup
+from src.config_web.migration import migrate_yaml_to_store
+from src.config_web.schema import ConfigSchema
+from src.config_web.store import ConfigStore
+from src.persistence import PvYieldStore
+
+from .test_api import _FakeModule, _sample_config
+
+
+def _make_client(tmp_path, with_pv_store):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    schema = ConfigSchema()
+    store = ConfigStore(str(tmp_path / "backup.db"))
+    store.open()
+    migrate_yaml_to_store(_sample_config(), store, schema)
+
+    module = _FakeModule(_sample_config(), store, schema)
+    if with_pv_store:
+        pv_store = PvYieldStore(store)
+        pv_store.ensure_schema()
+        module.pv_yield_store = pv_store
+
+    init_api(store, schema, module)
+    init_backup(store, schema, module)
+    app.register_blueprint(config_bp)
+    app.register_blueprint(backup_bp)
+
+    client = app.test_client()
+    client.store = store
+    client.module = module
+    return client, store
+
+
+@pytest.fixture(name="client")
+def client_fixture(tmp_path):
+    """A backup API with a working yield store."""
+    client, store = _make_client(tmp_path, with_pv_store=True)
+    try:
+        yield client
+    finally:
+        store.close()
+
+
+@pytest.fixture(name="storeless_client")
+def storeless_client_fixture(tmp_path):
+    """A backup API whose yield store failed to initialise."""
+    client, store = _make_client(tmp_path, with_pv_store=False)
+    try:
+        yield client
+    finally:
+        store.close()
+
+
+def _seed_hours(client, days_ago=1, hours=(8, 12)):
+    """Record measured hours so there is history to back up."""
+    base = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    for hour in hours:
+        when = base.replace(hour=hour, minute=0, second=0, microsecond=0)
+        client.module.pv_yield_store.insert_hourly_record(
+            timestamp=when.isoformat(),
+            date=when.strftime("%Y-%m-%d"),
+            hour=hour,
+            timeframe_id=(hour // 6) + 1,
+            real_counter_kwh=1042.5,
+            real_delta_kwh=0.83,
+            forecast_kwh=0.91,
+            local_date=when.strftime("%Y-%m-%d"),
+            local_hour=hour,
+            local_offset_minutes=0,
+        )
+
+
+def _post(client, payload, query=""):
+    return client.post(
+        f"/api/backup/import{query}",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+class TestBackupInfo:
+    """What the panel shows before anything is downloaded."""
+
+    def test_info_counts_both_datasets(self, client):
+        _seed_hours(client)
+        data = client.get("/api/backup/info").get_json()
+
+        assert data["settings"]["count"] > 50
+        assert data["pv_yield_history"]["count"] == 2
+        assert data["pv_yield_history"]["available"] is True
+        assert data["retention_days"] == 7
+
+    def test_info_warns_the_file_holds_secrets(self, client):
+        """A backup is never masked, so the UI has to say so."""
+        assert client.get("/api/backup/info").get_json()["contains_secrets"] is True
+
+    def test_info_degrades_without_a_yield_store(self, storeless_client):
+        data = storeless_client.get("/api/backup/info").get_json()
+
+        assert data["pv_yield_history"]["available"] is False
+        assert data["pv_yield_history"]["count"] == 0
+        assert data["settings"]["count"] > 50
+
+
+class TestBackupExport:
+    """The file's shape is a compatibility contract."""
+
+    def test_export_is_flat_with_metadata(self, client):
+        data = client.get("/api/backup/export").get_json()
+
+        assert data["_format"] == "eos-connect-backup"
+        assert data["_version"] == 1
+        assert data["_exported_at"]
+        # Settings sit at the top level, not inside an envelope — an older build
+        # resolves top-level keys against its schema and would import nothing from a
+        # nested file while reporting success.
+        assert data["battery.capacity_wh"] == 10000
+        assert "settings" not in data
+
+    def test_export_carries_yield_history(self, client):
+        _seed_hours(client)
+        rows = client.get("/api/backup/export").get_json()["pv_yield_history"]
+
+        assert len(rows) == 2
+        assert rows[0]["real_delta_kwh"] == 0.83
+
+    def test_export_omits_local_only_row_fields(self, client):
+        _seed_hours(client)
+        row = client.get("/api/backup/export").get_json()["pv_yield_history"][0]
+
+        assert "id" not in row
+        assert "created_at" not in row
+        assert "real_counter_kwh" not in row
+
+    def test_export_degrades_to_empty_history(self, storeless_client):
+        data = storeless_client.get("/api/backup/export").get_json()
+
+        assert data["pv_yield_history"] == []
+        assert data["battery.capacity_wh"] == 10000
+
+    def test_export_honours_dataset_selection(self, client):
+        _seed_hours(client)
+
+        only_history = client.get("/api/backup/export?include=pv_yield_history").get_json()
+        assert "battery.capacity_wh" not in only_history
+        assert len(only_history["pv_yield_history"]) == 2
+
+        only_settings = client.get("/api/backup/export?include=settings").get_json()
+        assert only_settings["battery.capacity_wh"] == 10000
+        assert "pv_yield_history" not in only_settings
+
+    def test_export_matches_the_config_endpoint_for_settings(self, client):
+        """Both files must carry exactly the same settings."""
+        backup = client.get("/api/backup/export").get_json()
+        config = client.get("/api/config/export").get_json()
+
+        assert {k: v for k, v in backup.items() if k in config} == config
+
+
+class TestBackupRestore:
+    """Restoring, and previewing a restore."""
+
+    def test_round_trip_restores_history(self, client):
+        _seed_hours(client)
+        backup = client.get("/api/backup/export").get_json()
+        client.store.execute("DELETE FROM pv_yield_history")
+        assert client.module.pv_yield_store.get_all_history() == []
+
+        result = _post(client, backup).get_json()
+
+        assert result["pv_yield_history"]["imported"] == 2
+        assert len(client.module.pv_yield_store.get_all_history()) == 2
+
+    def test_restore_is_idempotent(self, client):
+        _seed_hours(client)
+        backup = client.get("/api/backup/export").get_json()
+        client.store.execute("DELETE FROM pv_yield_history")
+
+        _post(client, backup)
+        _post(client, backup)
+
+        assert len(client.module.pv_yield_store.get_all_history()) == 2
+
+    def test_restore_defaults_to_replace(self, client):
+        """The stored config must end up matching the file exactly."""
+        backup = client.get("/api/backup/export").get_json()
+        client.store.set("battery.capacity_wh", 99999)
+
+        result = _post(client, backup).get_json()
+
+        assert result["mode"] == "replace"
+        assert client.store.get("battery.capacity_wh") == 10000
+
+    def test_restore_removes_settings_absent_from_the_file(self, client):
+        backup = client.get("/api/backup/export").get_json()
+        del backup["eos.port"]
+
+        result = _post(client, backup).get_json()
+
+        assert "eos.port" in result["settings"]["removed"]
+        assert not client.store.has_key("eos.port")
+
+    def test_merge_mode_keeps_them(self, client):
+        backup = client.get("/api/backup/export").get_json()
+        del backup["eos.port"]
+
+        result = _post(client, backup, "?mode=merge").get_json()
+
+        assert result["settings"]["removed"] == []
+        assert client.store.has_key("eos.port")
+
+    def test_dry_run_writes_nothing(self, client):
+        _seed_hours(client)
+        backup = client.get("/api/backup/export").get_json()
+        client.store.execute("DELETE FROM pv_yield_history")
+        client.store.set("battery.capacity_wh", 99999)
+
+        result = _post(client, backup, "?dry_run=1").get_json()
+
+        assert result["dry_run"] is True
+        assert result["pv_yield_history"]["valid"] == 2
+        assert "imported" not in result["pv_yield_history"]
+        # Nothing changed on disk.
+        assert client.module.pv_yield_store.get_all_history() == []
+        assert client.store.get("battery.capacity_wh") == 99999
+
+    def test_dry_run_names_the_settings_it_would_remove(self, client):
+        """The whole point of the preview: no surprises after confirming."""
+        backup = client.get("/api/backup/export").get_json()
+        del backup["eos.port"]
+
+        result = _post(client, backup, "?dry_run=1").get_json()
+
+        assert "eos.port" in result["settings"]["removed"]
+        assert client.store.has_key("eos.port")
+
+    def test_restore_reports_the_file_metadata_back(self, client):
+        backup = client.get("/api/backup/export").get_json()
+        result = _post(client, backup, "?dry_run=1").get_json()
+
+        assert result["format"] == "eos-connect-backup"
+        assert result["version"] == 1
+        assert result["exported_at"] == backup["_exported_at"]
+
+    def test_restore_honours_dataset_selection(self, client):
+        _seed_hours(client)
+        backup = client.get("/api/backup/export").get_json()
+        client.store.execute("DELETE FROM pv_yield_history")
+        client.store.set("battery.capacity_wh", 99999)
+
+        _post(client, backup, "?include=pv_yield_history")
+
+        assert len(client.module.pv_yield_store.get_all_history()) == 2
+        assert client.store.get("battery.capacity_wh") == 99999
+
+    def test_restore_degrades_without_a_yield_store(self, storeless_client):
+        payload = {
+            "_format": "eos-connect-backup",
+            "battery.capacity_wh": 12000,
+            "pv_yield_history": [{"timestamp": "2026-08-19T06:00:00+00:00"}],
+        }
+        result = _post(storeless_client, payload).get_json()
+
+        assert result["pv_yield_history"]["available"] is False
+        assert result["pv_yield_history"]["present_in_file"] == 1
+        assert storeless_client.store.get("battery.capacity_wh") == 12000
+
+    def test_restore_rejects_a_non_object_body(self, client):
+        resp = client.post(
+            "/api/backup/import", data=json.dumps([1, 2]), content_type="application/json"
+        )
+        assert resp.status_code == 400
+
+    def test_legacy_config_file_still_restores(self, client):
+        """A flat export from before this feature carries no marker at all."""
+        legacy = client.get("/api/config/export").get_json()
+        legacy["battery.capacity_wh"] = 13500
+        client.store.set("battery.capacity_wh", 1)
+
+        result = _post(client, legacy).get_json()
+
+        assert result["format"] is None
+        assert client.store.get("battery.capacity_wh") == 13500
+
+    def test_seed_mode_shifts_a_stale_backup_into_the_window(self, client):
+        _seed_hours(client, days_ago=25)
+        backup = client.get("/api/backup/export").get_json()
+        client.store.execute("DELETE FROM pv_yield_history")
+
+        result = _post(client, backup, "?history_mode=seed").get_json()["pv_yield_history"]
+
+        assert result["shift_days"] == 24
+        assert result["imported"] == 2
+        stored = client.module.pv_yield_store.get_all_history()
+        assert {row["origin"] for row in stored} == {"seeded"}
+
+    def test_preview_flags_a_stale_backup_for_seeding(self, client):
+        _seed_hours(client, days_ago=25)
+        backup = client.get("/api/backup/export").get_json()
+
+        preview = _post(client, backup, "?dry_run=1").get_json()["pv_yield_history"]
+
+        assert preview["age_days"] == 25
+        assert preview["seed_recommended"] is True
+        assert preview["retention_days"] == 7
+
+    def test_preview_does_not_flag_a_fresh_backup(self, client):
+        _seed_hours(client, days_ago=1)
+        backup = client.get("/api/backup/export").get_json()
+
+        preview = _post(client, backup, "?dry_run=1").get_json()["pv_yield_history"]
+
+        assert preview["seed_recommended"] is False

--- a/tests/config_web/test_backup.py
+++ b/tests/config_web/test_backup.py
@@ -99,6 +99,7 @@ class TestBackupInfo:
     """What the panel shows before anything is downloaded."""
 
     def test_info_counts_both_datasets(self, client):
+        """Both datasets are reported with the counts the panel shows."""
         _seed_hours(client)
         data = client.get("/api/backup/info").get_json()
 
@@ -107,11 +108,20 @@ class TestBackupInfo:
         assert data["pv_yield_history"]["available"] is True
         assert data["retention_days"] == 7
 
+    def test_info_survives_a_corrupt_retention_setting(self, client):
+        """A garbage retention value must not take the whole panel down with it."""
+        client.store.set("pv_autoscaling.retention_days", "not a number")
+
+        data = client.get("/api/backup/info").get_json()
+
+        assert data["retention_days"] == 7
+
     def test_info_warns_the_file_holds_secrets(self, client):
         """A backup is never masked, so the UI has to say so."""
         assert client.get("/api/backup/info").get_json()["contains_secrets"] is True
 
     def test_info_degrades_without_a_yield_store(self, storeless_client):
+        """A missing yield store is reported, not raised."""
         data = storeless_client.get("/api/backup/info").get_json()
 
         assert data["pv_yield_history"]["available"] is False
@@ -123,6 +133,7 @@ class TestBackupExport:
     """The file's shape is a compatibility contract."""
 
     def test_export_is_flat_with_metadata(self, client):
+        """Settings at the top level, marked with an explicit format version."""
         data = client.get("/api/backup/export").get_json()
 
         assert data["_format"] == "eos-connect-backup"
@@ -135,6 +146,7 @@ class TestBackupExport:
         assert "settings" not in data
 
     def test_export_carries_yield_history(self, client):
+        """Measured hours travel with the settings."""
         _seed_hours(client)
         rows = client.get("/api/backup/export").get_json()["pv_yield_history"]
 
@@ -142,6 +154,7 @@ class TestBackupExport:
         assert rows[0]["real_delta_kwh"] == 0.83
 
     def test_export_omits_local_only_row_fields(self, client):
+        """Database artifacts and the meter counter do not travel."""
         _seed_hours(client)
         row = client.get("/api/backup/export").get_json()["pv_yield_history"][0]
 
@@ -150,12 +163,14 @@ class TestBackupExport:
         assert "real_counter_kwh" not in row
 
     def test_export_degrades_to_empty_history(self, storeless_client):
+        """No yield store means an empty history, not a failed export."""
         data = storeless_client.get("/api/backup/export").get_json()
 
         assert data["pv_yield_history"] == []
         assert data["battery.capacity_wh"] == 10000
 
     def test_export_honours_dataset_selection(self, client):
+        """Each dataset can be backed up on its own."""
         _seed_hours(client)
 
         only_history = client.get("/api/backup/export?include=pv_yield_history").get_json()
@@ -187,6 +202,7 @@ class TestBackupRestore:
     """Restoring, and previewing a restore."""
 
     def test_round_trip_restores_history(self, client):
+        """Export, wipe, import — the hours come back."""
         _seed_hours(client)
         backup = client.get("/api/backup/export").get_json()
         client.store.execute("DELETE FROM pv_yield_history")
@@ -198,6 +214,7 @@ class TestBackupRestore:
         assert len(client.module.pv_yield_store.get_all_history()) == 2
 
     def test_restore_is_idempotent(self, client):
+        """Restoring twice must not duplicate rows."""
         _seed_hours(client)
         backup = client.get("/api/backup/export").get_json()
         client.store.execute("DELETE FROM pv_yield_history")
@@ -218,6 +235,7 @@ class TestBackupRestore:
         assert client.store.get("battery.capacity_wh") == 10000
 
     def test_restore_removes_settings_absent_from_the_file(self, client):
+        """Replace mode deletes what the file does not carry."""
         backup = client.get("/api/backup/export").get_json()
         del backup["eos.port"]
 
@@ -227,6 +245,7 @@ class TestBackupRestore:
         assert not client.store.has_key("eos.port")
 
     def test_merge_mode_keeps_them(self, client):
+        """Merge mode leaves settings the file does not carry alone."""
         backup = client.get("/api/backup/export").get_json()
         del backup["eos.port"]
 
@@ -236,6 +255,7 @@ class TestBackupRestore:
         assert client.store.has_key("eos.port")
 
     def test_dry_run_writes_nothing(self, client):
+        """The preview must not touch either table."""
         _seed_hours(client)
         backup = client.get("/api/backup/export").get_json()
         client.store.execute("DELETE FROM pv_yield_history")
@@ -261,6 +281,7 @@ class TestBackupRestore:
         assert client.store.has_key("eos.port")
 
     def test_restore_reports_the_file_metadata_back(self, client):
+        """The response echoes what the file claimed to be."""
         backup = client.get("/api/backup/export").get_json()
         result = _post(client, backup, "?dry_run=1").get_json()
 
@@ -269,6 +290,7 @@ class TestBackupRestore:
         assert result["exported_at"] == backup["_exported_at"]
 
     def test_restore_honours_dataset_selection(self, client):
+        """Restoring one dataset must not touch the other."""
         _seed_hours(client)
         backup = client.get("/api/backup/export").get_json()
         client.store.execute("DELETE FROM pv_yield_history")
@@ -291,6 +313,7 @@ class TestBackupRestore:
         assert client.store.get("battery.capacity_wh") == 99999
 
     def test_restore_degrades_without_a_yield_store(self, storeless_client):
+        """Settings still restore; the history is reported as unavailable."""
         payload = {
             "_format": "eos-connect-backup",
             "battery.capacity_wh": 12000,
@@ -303,6 +326,7 @@ class TestBackupRestore:
         assert storeless_client.store.get("battery.capacity_wh") == 12000
 
     def test_restore_rejects_a_non_object_body(self, client):
+        """A JSON array is not a backup."""
         resp = client.post(
             "/api/backup/import", data=json.dumps([1, 2]), content_type="application/json"
         )
@@ -320,6 +344,7 @@ class TestBackupRestore:
         assert client.store.get("battery.capacity_wh") == 13500
 
     def test_seed_mode_shifts_a_stale_backup_into_the_window(self, client):
+        """Old rows land inside the retention window, marked seeded."""
         _seed_hours(client, days_ago=25)
         backup = client.get("/api/backup/export").get_json()
         client.store.execute("DELETE FROM pv_yield_history")
@@ -332,6 +357,7 @@ class TestBackupRestore:
         assert {row["origin"] for row in stored} == {"seeded"}
 
     def test_preview_flags_a_stale_backup_for_seeding(self, client):
+        """The preview reports the age that makes shifting worthwhile."""
         _seed_hours(client, days_ago=25)
         backup = client.get("/api/backup/export").get_json()
 
@@ -342,9 +368,38 @@ class TestBackupRestore:
         assert preview["retention_days"] == 7
 
     def test_preview_does_not_flag_a_fresh_backup(self, client):
+        """A recent backup needs no shifting, so none is recommended."""
         _seed_hours(client, days_ago=1)
         backup = client.get("/api/backup/export").get_json()
 
         preview = _post(client, backup, "?dry_run=1").get_json()["pv_yield_history"]
 
         assert preview["seed_recommended"] is False
+
+
+class TestPreviewClassifiesFields:
+    """The preview must say what a restore would apply live and what needs a restart."""
+
+    def test_dry_run_separates_live_from_restart_required(self, client):
+        """Knowing a restart is coming is part of deciding whether to restore now."""
+        backup = client.get("/api/backup/export").get_json()
+        backup["price.feed_in_price"] = 0.27          # hot-reloadable
+        backup["eos_connect_web_port"] = 8099         # needs a restart
+
+        settings = _post(client, backup, "?dry_run=1").get_json()["settings"]
+
+        assert "price.feed_in_price" in settings["hot_reloaded"]
+        assert "eos_connect_web_port" in settings["restart_required"]
+        # Still a preview: neither value reached the store.
+        assert client.store.get("price.feed_in_price") != 0.27
+
+    def test_dry_run_reports_nothing_to_do_for_an_identical_file(self, client):
+        """Re-restoring the current state must not claim pending changes."""
+        backup = client.get("/api/backup/export").get_json()
+
+        settings = _post(client, backup, "?dry_run=1").get_json()["settings"]
+
+        assert settings["changed"] == 0
+        assert settings["removed"] == []
+        assert settings["hot_reloaded"] == []
+        assert settings["restart_required"] == []

--- a/tests/config_web/test_runtime_import_layout.py
+++ b/tests/config_web/test_runtime_import_layout.py
@@ -32,10 +32,12 @@ def _import_in_runtime_layout(module: str):
 
 
 def test_config_web_imports_as_a_top_level_package():
+    """config_web must import with src/ as the root, as the container runs it."""
     result = _import_in_runtime_layout("config_web")
     assert result.returncode == 0, result.stderr
 
 
 def test_persistence_imports_as_a_top_level_package():
+    """persistence must import the same way — config_web depends on it."""
     result = _import_in_runtime_layout("persistence")
     assert result.returncode == 0, result.stderr

--- a/tests/config_web/test_runtime_import_layout.py
+++ b/tests/config_web/test_runtime_import_layout.py
@@ -1,0 +1,41 @@
+"""
+Guard against imports that only break outside the test suite.
+
+Every other test imports ``src.config_web``, where ``src`` is a package and a relative
+``from ..other_package import x`` resolves fine.  At runtime that is not the layout: the
+Dockerfile copies ``src/`` to ``/app`` and the app starts as ``python eos_connect.py``,
+so ``config_web``, ``persistence`` and ``interfaces`` are *sibling top-level* packages
+and any relative import across them raises ImportError.
+
+That break has happened before — ``config_web/__init__.py`` carries a try/except
+fallback for exactly this reason — and the suite structurally cannot see it.  This runs
+the real layout in a subprocess instead.
+"""
+
+import os
+import subprocess
+import sys
+
+SRC = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "src")
+
+
+def _import_in_runtime_layout(module: str):
+    """Import *module* the way the container does: from inside src/, as top-level."""
+    return subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        cwd=SRC,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+
+
+def test_config_web_imports_as_a_top_level_package():
+    result = _import_in_runtime_layout("config_web")
+    assert result.returncode == 0, result.stderr
+
+
+def test_persistence_imports_as_a_top_level_package():
+    result = _import_in_runtime_layout("persistence")
+    assert result.returncode == 0, result.stderr

--- a/tests/interfaces/test_pv_autoscaler.py
+++ b/tests/interfaces/test_pv_autoscaler.py
@@ -416,6 +416,7 @@ def test_status_counts_restored_hours():
 
 
 def test_status_reports_no_restored_hours_for_a_normal_install():
+    """An install that never restored a backup reports none."""
     store = InMemoryPvYieldStore()
     store.rows = _day_rows("2026-08-19", 6.0, 6.0)
     autoscaler = _autoscaler(store, today="2026-08-20")

--- a/tests/interfaces/test_pv_autoscaler.py
+++ b/tests/interfaces/test_pv_autoscaler.py
@@ -359,3 +359,65 @@ def test_empty_store_degrades_to_empty_history():
 
     assert autoscaler.get_aggregated_history() == {"days": [], "summary_by_timeframe": {}}
     assert autoscaler.get_todays_partial_data() == {}
+
+
+# ---------------------------------------------------------------------------
+# Provenance — restored days must not read as locally measured
+# ---------------------------------------------------------------------------
+
+def test_aggregated_history_labels_days_measured_by_default():
+    """Rows with no origin came from this system's own meter."""
+    store = InMemoryPvYieldStore()
+    store.rows = _day_rows("2026-08-19", 6.0, 6.0)
+    autoscaler = _autoscaler(store, today="2026-08-20")
+
+    assert autoscaler.get_aggregated_history()["days"][0]["origin"] == "measured"
+
+
+def test_aggregated_history_labels_a_seeded_day():
+    """A day made entirely of restored rows is not a measurement."""
+    store = InMemoryPvYieldStore()
+    rows = _day_rows("2026-08-19", 6.0, 6.0)
+    for row in rows:
+        row["origin"] = "seeded"
+    store.rows = rows
+    autoscaler = _autoscaler(store, today="2026-08-20")
+
+    assert autoscaler.get_aggregated_history()["days"][0]["origin"] == "seeded"
+
+
+def test_a_restored_day_topped_up_by_real_collection_reads_as_measured():
+    """One genuinely measured hour is enough to stop calling the day seeded."""
+    store = InMemoryPvYieldStore()
+    rows = _day_rows("2026-08-19", 6.0, 6.0)
+    for row in rows:
+        row["origin"] = "seeded"
+    rows[8]["origin"] = None
+    store.rows = rows
+    autoscaler = _autoscaler(store, today="2026-08-20")
+
+    assert autoscaler.get_aggregated_history()["days"][0]["origin"] == "measured"
+
+
+def test_status_counts_restored_hours():
+    """The panel needs to say how much of the window was not measured here."""
+    store = InMemoryPvYieldStore()
+    measured = _day_rows("2026-08-19", 6.0, 6.0)
+    restored = _day_rows("2026-08-18", 6.0, 6.0)
+    for row in restored:
+        row["origin"] = "imported"
+    store.rows = measured + restored
+    autoscaler = _autoscaler(store, today="2026-08-20")
+
+    status = autoscaler.get_status()
+
+    assert status["total_hours_recorded"] == 48
+    assert status["restored_hours"] == 24
+
+
+def test_status_reports_no_restored_hours_for_a_normal_install():
+    store = InMemoryPvYieldStore()
+    store.rows = _day_rows("2026-08-19", 6.0, 6.0)
+    autoscaler = _autoscaler(store, today="2026-08-20")
+
+    assert autoscaler.get_status()["restored_hours"] == 0

--- a/tests/persistence/test_pv_yield_store.py
+++ b/tests/persistence/test_pv_yield_store.py
@@ -224,3 +224,181 @@ def test_duplicate_timestamps_are_repaired_on_migration(tmp_path):
         assert rows[0]["real_delta_kwh"] == pytest.approx(9.0)
     finally:
         store.close()
+
+
+# ----------------------------------------------------------------------
+# Backup restore
+# ----------------------------------------------------------------------
+
+
+def _exported(local_dt, **overrides):
+    """A row shaped the way backup export writes it (no id, created_at or counter)."""
+    row = {
+        "timestamp": local_dt.astimezone(timezone.utc).isoformat(),
+        "date": local_dt.strftime("%Y-%m-%d"),
+        "hour": local_dt.hour,
+        "timeframe_id": (local_dt.hour // 6) + 1,
+        "real_delta_kwh": 1.0,
+        "forecast_kwh": 1.2,
+        "local_date": local_dt.strftime("%Y-%m-%d"),
+        "local_hour": local_dt.hour,
+        "local_offset_minutes": 60,
+    }
+    row.update(overrides)
+    return row
+
+
+def _yesterday(hour=10):
+    return datetime.now(timezone.utc).replace(
+        hour=hour, minute=0, second=0, microsecond=0
+    ) - timedelta(days=1)
+
+
+def test_get_all_history_ignores_retention_window(pv_store):
+    """Export must capture whatever is on disk, not just the scored window."""
+    old = datetime.now(timezone.utc) - timedelta(days=90)
+    _record(pv_store, old)
+    _record(pv_store, _yesterday())
+
+    assert len(pv_store.get_history_last_n_days(7)) == 1
+    assert len(pv_store.get_all_history()) == 2
+
+
+def test_import_rows_restores_measurements(pv_store):
+    """A valid row lands with its delta and forecast intact."""
+    result = pv_store.import_rows([_exported(_yesterday(9))])
+
+    assert result["imported"] == 1
+    assert result["skipped"] == 0
+    stored = pv_store.get_all_history()
+    assert len(stored) == 1
+    assert stored[0]["real_delta_kwh"] == 1.0
+    assert stored[0]["forecast_kwh"] == 1.2
+
+
+def test_import_never_restores_the_meter_counter(pv_store):
+    """A restored counter would poison the autoscaler's first live delta."""
+    pv_store.import_rows([_exported(_yesterday(), real_counter_kwh=98765.0)])
+
+    assert pv_store.get_all_history()[0]["real_counter_kwh"] is None
+    assert pv_store.get_latest_record()["real_counter_kwh"] is None
+
+
+def test_import_marks_rows_as_imported(pv_store):
+    """Restored rows must be distinguishable from locally measured ones."""
+    pv_store.import_rows([_exported(_yesterday())])
+    assert pv_store.get_all_history()[0]["origin"] == "imported"
+
+
+def test_measured_rows_have_no_origin(pv_store):
+    """The normal collection path leaves origin NULL."""
+    _record(pv_store, _yesterday())
+    assert pv_store.get_all_history()[0]["origin"] is None
+
+
+def test_import_does_not_relabel_an_existing_measured_row(pv_store):
+    """An hour measured here stays measured even if a backup also carries it."""
+    when = _yesterday(11)
+    _record(pv_store, when)
+    pv_store.import_rows([_exported(when)])
+
+    stored = pv_store.get_all_history()
+    assert len(stored) == 1
+    assert stored[0]["origin"] is None
+
+
+def test_import_is_idempotent(pv_store):
+    """Restoring the same file twice must not duplicate rows."""
+    rows = [_exported(_yesterday(8)), _exported(_yesterday(9))]
+    pv_store.import_rows(rows)
+    pv_store.import_rows(rows)
+
+    assert len(pv_store.get_all_history()) == 2
+
+
+def test_import_skips_malformed_rows_and_counts_them(pv_store):
+    """One bad row must not cost the others."""
+    result = pv_store.import_rows(
+        [
+            _exported(_yesterday(8)),
+            {"date": "2026-08-19"},                                # no timestamp
+            _exported(_yesterday(9), real_delta_kwh=-5),           # negative energy
+            _exported(_yesterday(10), forecast_kwh="not a number"),
+            "definitely not a row",
+        ]
+    )
+
+    assert result["imported"] == 1
+    assert result["skipped"] == 4
+    assert len(result["invalid"]) == 4
+    assert len(pv_store.get_all_history()) == 1
+
+
+def test_import_derives_timeframe_from_hour(pv_store):
+    """A row without timeframe_id still buckets correctly."""
+    row = _exported(_yesterday(14))
+    del row["timeframe_id"]
+    pv_store.import_rows([row])
+
+    assert pv_store.get_all_history()[0]["timeframe_id"] == 3
+
+
+def test_import_reconstructs_local_fields_from_timestamp(pv_store):
+    """A row predating the local_* columns is still usable."""
+    when = _yesterday(7)
+    row = _exported(when)
+    for key in ("date", "hour", "local_date", "local_hour", "local_offset_minutes"):
+        del row[key]
+    pv_store.import_rows([row])
+
+    stored = pv_store.get_all_history()[0]
+    assert stored["local_hour"] == 7
+    assert stored["local_date"] == when.strftime("%Y-%m-%d")
+
+
+def test_import_reports_rows_outside_retention(pv_store):
+    """Rows the next purge will delete are counted so the user can react."""
+    result = pv_store.import_rows(
+        [_exported(_yesterday()), _exported(datetime.now(timezone.utc) - timedelta(days=30))],
+        retention_days=7,
+    )
+
+    assert result["imported"] == 2
+    assert result["outside_retention"] == 1
+
+
+def test_import_accepts_naive_timestamps_as_utc(pv_store):
+    """Older exports wrote timestamps without an offset."""
+    result = pv_store.import_rows([_exported(_yesterday(6), timestamp="2026-08-19T06:00:00")])
+
+    assert result["imported"] == 1
+    assert pv_store.get_all_history()[0]["timestamp"].startswith("2026-08-19T06:00:00")
+
+
+def test_plan_import_writes_nothing(pv_store):
+    """The dry run must be a pure preview."""
+    plan = pv_store.plan_import([_exported(_yesterday())])
+
+    assert plan["valid"] == 1
+    assert pv_store.get_all_history() == []
+
+
+def test_plan_import_handles_empty_and_bogus_input(pv_store):
+    """A file with no history section must not be an error."""
+    for payload in ([], None, "nonsense", {}):
+        plan = pv_store.plan_import(payload)
+        assert plan["valid"] == 0
+        assert plan["rows"] == []
+
+
+def test_plan_recommends_seeding_only_past_retention(pv_store):
+    """Inside the window the backup can overlap real data, so shifting is not offered."""
+    recent = pv_store.plan_import([_exported(_yesterday())], retention_days=7)
+    assert recent["age_days"] == 1
+    assert recent["seed_recommended"] is False
+
+    stale = pv_store.plan_import(
+        [_exported(datetime.now(timezone.utc) - timedelta(days=20))], retention_days=7
+    )
+    assert stale["age_days"] == 20
+    assert stale["seed_recommended"] is True

--- a/tests/persistence/test_pv_yield_store.py
+++ b/tests/persistence/test_pv_yield_store.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from src.persistence import PvYieldStore
+from src.persistence.pv_yield_store import _shift_row
 from src.config_web.store import ConfigStore
 
 
@@ -402,3 +404,146 @@ def test_plan_recommends_seeding_only_past_retention(pv_store):
     )
     assert stale["age_days"] == 20
     assert stale["seed_recommended"] is True
+
+
+# ----------------------------------------------------------------------
+# Seeded (time-shifted) restore
+# ----------------------------------------------------------------------
+
+
+def _stale_day(days_ago, hours=(8, 12, 16)):
+    """One day of exported rows, `days_ago` days in the past."""
+    base = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return [_exported(base.replace(hour=h, minute=0, second=0, microsecond=0)) for h in hours]
+
+
+def test_seed_shifts_newest_row_to_yesterday(pv_store):
+    """A three-week-old backup must land inside the retention window."""
+    result = pv_store.import_rows(_stale_day(21), retention_days=7, mode="seed")
+
+    assert result["shift_days"] == 20
+    assert result["imported"] == 3
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+    assert {row["local_date"] for row in pv_store.get_all_history()} == {yesterday}
+
+
+def test_seed_preserves_hour_and_timeframe(pv_store):
+    """Shifting whole days must not move the solar hour."""
+    pv_store.import_rows(_stale_day(21, hours=(5, 13, 20)), retention_days=7, mode="seed")
+
+    stored = pv_store.get_all_history()
+    assert sorted(row["local_hour"] for row in stored) == [5, 13, 20]
+    assert sorted(row["timeframe_id"] for row in stored) == [1, 3, 4]
+
+
+def test_seed_marks_rows_as_seeded(pv_store):
+    """Seeded factors must never be mistaken for local measurements."""
+    pv_store.import_rows(_stale_day(21), retention_days=7, mode="seed")
+    assert {row["origin"] for row in pv_store.get_all_history()} == {"seeded"}
+
+
+def test_seed_keeps_measured_data_the_ratio_needs(pv_store):
+    """The measured/forecast pair is the whole point of seeding."""
+    pv_store.import_rows(_stale_day(21, hours=(10,)), retention_days=7, mode="seed")
+
+    stored = pv_store.get_all_history()[0]
+    assert stored["real_delta_kwh"] == 1.0
+    assert stored["forecast_kwh"] == 1.2
+    assert stored["real_counter_kwh"] is None
+
+
+def test_seed_drops_rows_still_outside_the_window(pv_store):
+    """Only the newest retention_days survive the shift; the rest are not written."""
+    rows = _stale_day(30, hours=(10,)) + _stale_day(21, hours=(10,))
+    result = pv_store.import_rows(rows, retention_days=7, mode="seed")
+
+    assert result["imported"] == 1
+    assert result["dropped_old"] == 1
+    assert len(pv_store.get_all_history()) == 1
+
+
+def test_seed_never_overwrites_an_existing_row(pv_store):
+    """A real measurement outranks a synthetic one landing on the same hour."""
+    yesterday = _yesterday(10)
+    _record(pv_store, yesterday, real_delta_kwh=9.9)
+
+    result = pv_store.import_rows(_stale_day(21, hours=(10,)), retention_days=7, mode="seed")
+
+    assert result["collisions"] == 1
+    assert result["imported"] == 0
+    stored = pv_store.get_all_history()
+    assert len(stored) == 1
+    assert stored[0]["real_delta_kwh"] == 9.9
+    assert stored[0]["origin"] is None
+
+
+def test_seed_is_a_no_op_for_a_fresh_backup(pv_store):
+    """Nothing to shift means the rows stay put and stay honest about it."""
+    result = pv_store.import_rows([_exported(_yesterday(10))], retention_days=7, mode="seed")
+
+    assert result["shift_days"] == 0
+    assert result["origin"] == "imported"
+    assert pv_store.get_all_history()[0]["origin"] == "imported"
+
+
+def test_seed_is_idempotent(pv_store):
+    """Running the same seeded restore twice must not double the rows."""
+    rows = _stale_day(21)
+    first = pv_store.import_rows(rows, retention_days=7, mode="seed")
+    second = pv_store.import_rows(rows, retention_days=7, mode="seed")
+
+    assert first["imported"] == 3
+    assert second["imported"] == 0
+    assert second["collisions"] == 3
+    assert len(pv_store.get_all_history()) == 3
+
+
+def test_shift_recomputes_the_utc_offset_for_the_new_date():
+    """Winter rows moved into summer must take the target date's DST offset."""
+    winter = {
+        "timestamp": "2026-01-15T09:00:00+00:00",
+        "date": "2026-01-15",
+        "hour": 10,
+        "timeframe_id": 2,
+        "real_delta_kwh": 1.0,
+        "forecast_kwh": 1.2,
+        "local_date": "2026-01-15",
+        "local_hour": 10,
+        "local_offset_minutes": 60,  # CET
+    }
+    shifted = _shift_row(winter, 181, ZoneInfo("Europe/Berlin"))
+
+    assert shifted["local_date"] == "2026-07-15"
+    assert shifted["local_hour"] == 10       # local wall clock preserved
+    assert shifted["local_offset_minutes"] == 120  # CEST
+    assert shifted["timestamp"].startswith("2026-07-15T08:00:00")
+
+
+def test_shift_keeps_local_hour_across_the_spring_transition():
+    """The UTC instant moves by 23h here; the local hour must not move at all."""
+    before = {
+        "timestamp": "2026-03-28T09:00:00+00:00",
+        "date": "2026-03-28",
+        "hour": 10,
+        "timeframe_id": 2,
+        "real_delta_kwh": 1.0,
+        "forecast_kwh": 1.2,
+        "local_date": "2026-03-28",
+        "local_hour": 10,
+        "local_offset_minutes": 60,
+    }
+    shifted = _shift_row(before, 1, ZoneInfo("Europe/Berlin"))
+
+    assert shifted["local_hour"] == 10
+    assert shifted["local_offset_minutes"] == 120
+    assert shifted["timestamp"].startswith("2026-03-29T08:00:00")
+
+
+def test_seed_uses_local_midnight_boundaries(pv_store):
+    """Late-evening rows must not slide into the next local day."""
+    pv_store.import_rows(
+        _stale_day(21, hours=(23,)), retention_days=7, tz_name="Europe/Berlin", mode="seed"
+    )
+    stored = pv_store.get_all_history()[0]
+    assert stored["local_hour"] == 23
+    assert stored["local_date"] == stored["date"]

--- a/tests/persistence/test_pv_yield_store.py
+++ b/tests/persistence/test_pv_yield_store.py
@@ -547,3 +547,113 @@ def test_seed_uses_local_midnight_boundaries(pv_store):
     stored = pv_store.get_all_history()[0]
     assert stored["local_hour"] == 23
     assert stored["local_date"] == stored["date"]
+
+
+# ----------------------------------------------------------------------
+# Rejecting a hostile or corrupt file
+# ----------------------------------------------------------------------
+
+
+def test_import_rejects_an_unparseable_timestamp(pv_store):
+    """The timestamp is the row's key; without a usable one there is no row."""
+    result = pv_store.import_rows([_exported(_yesterday(), timestamp="not-a-date")])
+
+    assert result["imported"] == 0
+    assert result["skipped"] == 1
+    assert "timestamp" in result["invalid"][0]["error"]
+
+
+@pytest.mark.parametrize("value", [True, {"kwh": 1}, [1], "abc", float("nan"), float("inf")])
+def test_import_rejects_non_numeric_energy(pv_store, value):
+    """A boolean, a container or a non-finite float is not an energy reading."""
+    result = pv_store.import_rows([_exported(_yesterday(), real_delta_kwh=value)])
+
+    assert result["imported"] == 0
+    assert result["skipped"] == 1
+
+
+def test_import_derives_the_hour_when_it_is_garbage(pv_store):
+    """An unusable hour falls back to the timestamp rather than sinking the row."""
+    when = _yesterday(9)
+    result = pv_store.import_rows(
+        [_exported(when, hour="lunchtime", local_hour=None, local_offset_minutes=0)]
+    )
+
+    assert result["imported"] == 1
+    assert pv_store.get_all_history()[0]["local_hour"] == 9
+
+
+def test_import_derives_the_date_when_it_is_garbage(pv_store):
+    """Same for a malformed date: the timestamp is authoritative."""
+    when = _yesterday(9)
+    result = pv_store.import_rows(
+        [_exported(when, date="31.12.2026", local_date="not-a-date", local_offset_minutes=0)]
+    )
+
+    assert result["imported"] == 1
+    assert pv_store.get_all_history()[0]["local_date"] == when.strftime("%Y-%m-%d")
+
+
+def test_import_ignores_an_out_of_range_hour(pv_store):
+    """Hour 47 is not a clock hour; the timestamp decides instead."""
+    when = _yesterday(9)
+    result = pv_store.import_rows(
+        [_exported(when, hour=47, local_hour=47, local_offset_minutes=0)]
+    )
+
+    assert result["imported"] == 1
+    assert pv_store.get_all_history()[0]["local_hour"] == 9
+
+
+def test_plan_reports_a_file_whose_every_row_is_unusable(pv_store):
+    """A wholly corrupt history must be counted, not mistaken for an empty one."""
+    plan = pv_store.plan_import([{"nope": 1}, {"timestamp": "???"}])
+
+    assert plan["total"] == 2
+    assert plan["skipped"] == 2
+    assert plan["valid"] == 0
+    assert plan["rows"] == []
+
+
+def test_seed_falls_back_to_utc_for_an_unknown_time_zone(pv_store):
+    """A time zone this build does not know must not abort the restore."""
+    result = pv_store.import_rows(
+        _stale_day(21, hours=(10,)),
+        retention_days=7,
+        tz_name="Mars/Olympus_Mons",
+        mode="seed",
+    )
+
+    assert result["imported"] == 1
+    assert result["shift_days"] == 20
+    assert pv_store.get_all_history()[0]["local_offset_minutes"] == 0
+
+
+def test_import_accepts_rows_with_an_unknown_forecast(pv_store):
+    """
+    A NULL forecast is normal, not corrupt.
+
+    The autoscaler stores NULL for an hour whose forecast was implausible or missing,
+    and for hours rebuilt by gap reconstruction. Those rows must survive a round trip -
+    rejecting them would quietly drop the measured yield they carry.
+    """
+    result = pv_store.import_rows(
+        [_exported(_yesterday(9), forecast_kwh=None, real_delta_kwh=None)]
+    )
+
+    assert result["imported"] == 1
+    stored = pv_store.get_all_history()[0]
+    assert stored["forecast_kwh"] is None
+    assert stored["real_delta_kwh"] is None
+
+
+def test_import_does_not_erase_a_stored_value_with_a_null(pv_store):
+    """COALESCE means a NULL in the file completes a row, never blanks it."""
+    when = _yesterday(9)
+    _record(pv_store, when, real_delta_kwh=2.5, forecast_kwh=3.0)
+
+    pv_store.import_rows([_exported(when, real_delta_kwh=None, forecast_kwh=None)])
+
+    stored = pv_store.get_all_history()[0]
+    assert stored["real_delta_kwh"] == 2.5
+    assert stored["forecast_kwh"] == 3.0

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,0 +1,171 @@
+"""
+Browser-driven tests for the web UI.
+
+These need Playwright and a Chromium build, neither of which is in ``requirements.txt``
+— CI has no browser, so the whole directory is skipped there.  To run them locally::
+
+    pip install playwright          # NOT pytest-playwright, see below
+    playwright install chromium
+    pytest tests/web
+
+Install ``playwright`` alone.  ``pytest-playwright`` depends on ``pytest-base-url``,
+whose ``base_url`` fixture is session-scoped and collides with the function-scoped
+``base_url`` in ``tests/interfaces/optimization_backends/test_optimization_backend_eos.py``,
+erroring out 44 unrelated tests.  Nothing here needs that plugin.
+
+Chromium also needs a few shared libraries.  With root that is
+``playwright install-deps chromium``; without it, run
+``scripts/install_playwright_deps_userspace.sh``, which unpacks them under
+``~/.cache/ms-playwright-deps`` — picked up automatically below.
+
+The rest of the suite exercises the REST layer; this exercises what the browser actually
+does with it.
+"""
+
+import logging
+import os
+import socket
+import threading
+
+import pytest
+from flask import Flask, jsonify, make_response, render_template_string, send_from_directory
+
+from src.config_web.api import config_bp, init_api
+from src.config_web.backup import backup_bp, init_backup
+from src.config_web.migration import migrate_yaml_to_store
+from src.config_web.schema import ConfigSchema
+from src.config_web.store import ConfigStore
+from src.persistence import PvYieldStore
+
+from tests.config_web.test_api import _FakeModule, _sample_config
+
+try:
+    import playwright.sync_api  # noqa: F401  pylint: disable=unused-import
+except ImportError:  # pragma: no cover - depends on the environment
+    # CI installs requirements.txt plus pytest and nothing else, so skip the whole
+    # directory rather than failing collection.
+    collect_ignore_glob = ["test_*.py"]
+
+# Shared libraries unpacked by scripts/install_playwright_deps_userspace.sh, for hosts
+# where Chromium's dependencies cannot be apt-installed.  Chromium is a subprocess, so
+# it inherits this; harmless when the directory does not exist.
+_USER_LIBS = os.path.join(os.path.expanduser("~"), ".cache", "ms-playwright-deps", "lib")
+if os.path.isdir(_USER_LIBS):
+    os.environ["LD_LIBRARY_PATH"] = os.pathsep.join(
+        [_USER_LIBS, os.environ.get("LD_LIBRARY_PATH", "")]
+    ).rstrip(os.pathsep)
+
+WEB_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "src", "web"
+)
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _build_app(store, schema, module):
+    """A minimal stand-in for the real server: the same blueprints and the same assets."""
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index():
+        with open(os.path.join(WEB_DIR, "index.html"), encoding="utf-8") as fh:
+            return make_response(render_template_string(fh.read(), asset_version="test"))
+
+    @app.route("/js/<path:filename>")
+    def js(filename):
+        return send_from_directory(
+            os.path.join(WEB_DIR, "js"), filename, mimetype="application/javascript"
+        )
+
+    @app.route("/css/<path:filename>")
+    def css(filename):
+        return send_from_directory(os.path.join(WEB_DIR, "css"), filename, mimetype="text/css")
+
+    # The dashboard polls these on load. They are not what these tests are about, but an
+    # unhandled 404 storm makes the console unreadable, so answer them minimally.
+    @app.route("/json/<path:_any>")
+    @app.route("/api/<path:_any>")
+    def stub(_any):
+        return jsonify({})
+
+    init_api(store, schema, module)
+    init_backup(store, schema, module)
+    app.register_blueprint(config_bp)
+    app.register_blueprint(backup_bp)
+    return app
+
+
+@pytest.fixture(name="server")
+def server_fixture(tmp_path):
+    """A real HTTP server on a throwaway database, serving the real UI assets."""
+    schema = ConfigSchema()
+    store = ConfigStore(str(tmp_path / "ui.db"))
+    store.open()
+    migrate_yaml_to_store(_sample_config(), store, schema)
+
+    module = _FakeModule(_sample_config(), store, schema)
+    pv_store = PvYieldStore(store)
+    pv_store.ensure_schema()
+    module.pv_yield_store = pv_store
+
+    port = _free_port()
+    app = _build_app(store, schema, module)
+    # The dashboard polls several endpoints a second; its request log drowns out the
+    # test output without saying anything useful.
+    logging.getLogger("werkzeug").setLevel(logging.ERROR)
+    thread = threading.Thread(
+        target=lambda: app.run(host="127.0.0.1", port=port, use_reloader=False),
+        daemon=True,
+    )
+    thread.start()
+
+    class Server:
+        url = f"http://127.0.0.1:{port}"
+
+    Server.store = store
+    Server.pv_store = pv_store
+    try:
+        yield Server
+    finally:
+        store.close()
+
+
+@pytest.fixture(name="page")
+def page_fixture(server):
+    """A browser page with the app open and the dashboard's own noise suppressed."""
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:  # pragma: no cover - environment dependent
+            pytest.skip(f"Chromium could not be launched: {exc}")
+
+        page = browser.new_page()
+        # The page pulls FontAwesome, Chart.js and a font from CDNs. Blocking them keeps
+        # the tests offline and fast; none of them affect the behaviour under test.
+        page.route("**://cdnjs.cloudflare.com/**", lambda route: route.abort())
+        page.route("**://cdn.jsdelivr.net/**", lambda route: route.abort())
+        page.route("**://fonts.cdnfonts.com/**", lambda route: route.abort())
+
+        # Fail fast: without this a broken selector costs the Playwright default of 30s.
+        page.set_default_timeout(8000)
+
+        page.goto(server.url, wait_until="domcontentloaded")
+        page.wait_for_function("typeof showBackupMenu === 'function'")
+
+        # The startup overlay only clears once the dashboard has rendered its chart from
+        # real optimizer output, which this harness does not serve. It covers the menu
+        # icon, so dismiss it — booting the dashboard is not what these tests are about.
+        page.evaluate(
+            "() => { const o = document.getElementById('overlay');"
+            " if (o) { o.style.display = 'none'; } }"
+        )
+        try:
+            yield page
+        finally:
+            browser.close()

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -123,7 +123,9 @@ def server_fixture(tmp_path):
     )
     thread.start()
 
-    class Server:
+    class Server:  # pylint: disable=too-few-public-methods
+        """Handle to the running app: its URL and the stores behind it."""
+
         url = f"http://127.0.0.1:{port}"
 
     Server.store = store
@@ -137,12 +139,16 @@ def server_fixture(tmp_path):
 @pytest.fixture(name="page")
 def page_fixture(server):
     """A browser page with the app open and the dashboard's own noise suppressed."""
-    from playwright.sync_api import sync_playwright
+    # Imported here, not at module scope: the directory is skipped when Playwright is
+    # absent, and a top-level import would run before that check.
+    from playwright.sync_api import sync_playwright  # pylint: disable=import-outside-toplevel
 
     with sync_playwright() as p:
         try:
             browser = p.chromium.launch()
-        except Exception as exc:  # pragma: no cover - environment dependent
+        # Playwright raises a variety of errors for a browser that will not start
+        # (missing libraries, no sandbox, out of memory); all of them mean "skip".
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             pytest.skip(f"Chromium could not be launched: {exc}")
 
         page = browser.new_page()

--- a/tests/web/test_backup_ui.py
+++ b/tests/web/test_backup_ui.py
@@ -400,3 +400,108 @@ def test_preview_explains_hours_it_will_not_write(server, page, tmp_path):
     body = page.inner_text("#full_screen_content")
     assert "Hours already measured here" in body
     assert "left untouched" in body
+
+
+# ----------------------------------------------------------------------
+# Layout and responsiveness
+# ----------------------------------------------------------------------
+
+# Wide enough for two columns, and a phone in portrait. isMobile() switches at 768.
+DESKTOP = {"width": 1920, "height": 1080}
+PHONE = {"width": 390, "height": 844}
+
+
+def test_cards_sit_side_by_side_on_a_wide_screen(server, page):
+    """A narrow centred column in a 1920px overlay is not how the other panels look."""
+    _seed_hours(server)
+    page.set_viewport_size(DESKTOP)
+    _open_panel(page)
+
+    backup = page.eval_on_selector("#ds-backup-settings", "e => e.getBoundingClientRect()")
+    restore_btn = page.eval_on_selector(
+        "#backup-restore-file + button", "e => e.getBoundingClientRect()"
+    )
+
+    # The restore action starts to the right of the backup action, not beneath it.
+    assert restore_btn["left"] > backup["left"] + 300
+    assert abs(restore_btn["top"] - backup["top"]) < 120
+
+
+def test_cards_stack_on_a_phone(server, page):
+    _seed_hours(server)
+    page.set_viewport_size(PHONE)
+    _open_panel(page)
+
+    backup = page.eval_on_selector("#ds-backup-settings", "e => e.getBoundingClientRect()")
+    restore_btn = page.eval_on_selector(
+        "#backup-restore-file + button", "e => e.getBoundingClientRect()"
+    )
+
+    assert restore_btn["top"] > backup["top"] + 100
+    assert abs(restore_btn["left"] - backup["left"]) < 40
+
+
+def test_panel_uses_the_full_overlay_width(server, page):
+    """The other overlays fill the width; a centred 820px column looked out of place."""
+    _seed_hours(server)
+    page.set_viewport_size(DESKTOP)
+    _open_panel(page)
+
+    content = page.eval_on_selector("#full_screen_content", "e => e.clientWidth")
+    widest = page.eval_on_selector_all(
+        "#full_screen_content > *", "els => Math.max(...els.map(e => e.offsetWidth))"
+    )
+
+    assert widest > content * 0.9
+
+
+@pytest.mark.parametrize("viewport", [DESKTOP, PHONE, {"width": 820, "height": 1180}])
+def test_nothing_overflows_horizontally(server, page, tmp_path, viewport):
+    """Guards the squeeze that pushed the dataset labels into a two-character ribbon."""
+    _seed_hours(server)
+    path, _ = _write_backup(tmp_path, page)
+    page.set_viewport_size(viewport)
+
+    _open_panel(page)
+    assert page.eval_on_selector(
+        "#full_screen_content", "e => e.scrollWidth <= e.clientWidth + 1"
+    )
+
+    _choose_file(page, path)
+    assert page.eval_on_selector(
+        "#full_screen_content", "e => e.scrollWidth <= e.clientWidth + 1"
+    )
+
+
+def test_explainer_is_present_when_idle_and_hidden_mid_restore(server, page, tmp_path):
+    """It fills the desktop dead space, but must not compete with the review."""
+    path, _ = _write_backup(tmp_path, page)
+    page.set_viewport_size(DESKTOP)
+
+    _open_panel(page)
+    assert "How it works:" in page.inner_text("#full_screen_content")
+
+    _choose_file(page, path)
+    assert "How it works:" not in page.inner_text("#full_screen_content")
+
+
+def test_result_counts_are_laid_out_as_a_row_on_a_wide_screen(server, page, tmp_path):
+    _seed_hours(server)
+    path, _ = _write_backup(tmp_path, page)
+    server.store.execute("DELETE FROM pv_yield_history")
+    page.set_viewport_size(DESKTOP)
+
+    _open_panel(page)
+    _choose_file(page, path)
+    page.click("text=Restore now")
+    page.wait_for_selector("text=Restore complete")
+
+    tops = page.eval_on_selector_all(
+        "#full_screen_content div:has(> div + div)",
+        """els => els
+            .filter(e => /^\\d/.test(
+                e.querySelectorAll(':scope > div')[1]?.textContent?.trim() || ''))
+            .map(e => e.offsetTop)""",
+    )
+    assert len(tops) >= 2
+    assert len(set(tops)) == 1, "count tiles should share one row"

--- a/tests/web/test_backup_ui.py
+++ b/tests/web/test_backup_ui.py
@@ -83,6 +83,7 @@ def test_menu_offers_backup_and_restore(page):
 
 
 def test_panel_opens_from_the_menu(page):
+    """Both halves of the feature are on screen when the panel opens."""
     _open_panel(page)
 
     assert page.is_visible("text=Create a backup")
@@ -90,6 +91,7 @@ def test_panel_opens_from_the_menu(page):
 
 
 def test_panel_reports_what_the_install_holds(server, page):
+    """The counts come from the live install, not from placeholders."""
     _seed_hours(server, hours=(8, 12, 16))
     _open_panel(page)
 
@@ -108,6 +110,7 @@ def test_panel_warns_that_the_file_holds_secrets(page):
 
 
 def test_history_shows_as_unavailable_when_there_is_none(page):
+    """An empty history says so rather than showing a bare zero."""
     _open_panel(page)
 
     assert "nothing recorded yet" in page.inner_text("#full_screen_content")
@@ -119,6 +122,7 @@ def test_history_shows_as_unavailable_when_there_is_none(page):
 
 
 def test_download_produces_a_backup_file(server, page):
+    """The download is offered under a name that says what it is."""
     _seed_hours(server)
     _open_panel(page)
 
@@ -131,6 +135,7 @@ def test_download_produces_a_backup_file(server, page):
 
 
 def test_downloaded_file_carries_both_datasets(server, page, tmp_path):
+    """What lands on disk is the whole install, minus the meter counter."""
     _seed_hours(server)
     _open_panel(page)
 
@@ -147,6 +152,7 @@ def test_downloaded_file_carries_both_datasets(server, page, tmp_path):
 
 
 def test_deselecting_a_dataset_leaves_it_out_of_the_download(server, page, tmp_path):
+    """The checkboxes decide what the file contains."""
     _seed_hours(server)
     _open_panel(page)
     page.uncheck("#ds-backup-pv_yield_history")
@@ -195,6 +201,7 @@ def test_preview_names_the_settings_it_would_remove(server, page, tmp_path):
 
 
 def test_confirming_applies_the_restore(server, page, tmp_path):
+    """Confirming is what finally writes."""
     path, _ = _write_backup(tmp_path, page)
     server.store.set("battery.capacity_wh", 99999)
 
@@ -207,6 +214,7 @@ def test_confirming_applies_the_restore(server, page, tmp_path):
 
 
 def test_restore_result_reports_what_happened(server, page, tmp_path):
+    """The result names what was restored, not just that it worked."""
     _seed_hours(server)
     path, _ = _write_backup(tmp_path, page)
     server.store.execute("DELETE FROM pv_yield_history")
@@ -222,6 +230,7 @@ def test_restore_result_reports_what_happened(server, page, tmp_path):
 
 
 def test_cancel_discards_the_pending_restore(server, page, tmp_path):
+    """Backing out must leave the install untouched."""
     path, _ = _write_backup(tmp_path, page)
     server.store.set("battery.capacity_wh", 99999)
 
@@ -234,6 +243,7 @@ def test_cancel_discards_the_pending_restore(server, page, tmp_path):
 
 
 def test_merge_mode_keeps_settings_the_file_lacks(server, page, tmp_path):
+    """Switching to merge re-previews and then keeps the extra settings."""
     _, data = _write_backup(tmp_path, page)
     del data["eos.port"]
     path = tmp_path / "merge.json"
@@ -283,7 +293,7 @@ def test_backup_and_restore_selections_are_independent(server, page, tmp_path):
     assert page.evaluate("() => backupManager.forBackup.pv_yield_history") is True
 
 
-def test_preview_replaces_the_backup_card(server, page, tmp_path):
+def test_preview_replaces_the_backup_card(page, tmp_path):
     """Mid-restore the Confirm button must not sit below an irrelevant card."""
     path, _ = _write_backup(tmp_path, page)
 
@@ -328,6 +338,7 @@ def _stale_backup(page, tmp_path, days_ago=25):
 
 
 def test_stale_backup_preselects_time_shifting(page, tmp_path):
+    """An unusably old backup offers the shift by default, with its reason."""
     path = _stale_backup(page, tmp_path)
 
     _open_panel(page)
@@ -340,6 +351,7 @@ def test_stale_backup_preselects_time_shifting(page, tmp_path):
 
 
 def test_fresh_backup_does_not_preselect_time_shifting(server, page, tmp_path):
+    """A recent backup warns against shifting instead of offering it."""
     _seed_hours(server)
     path, _ = _write_backup(tmp_path, page)
 
@@ -351,6 +363,7 @@ def test_fresh_backup_does_not_preselect_time_shifting(server, page, tmp_path):
 
 
 def test_seeded_restore_marks_the_rows(server, page, tmp_path):
+    """Seeded rows are labelled and carry no meter reading."""
     path = _stale_backup(page, tmp_path)
 
     _open_panel(page)
@@ -371,7 +384,7 @@ def test_seeded_restore_marks_the_rows(server, page, tmp_path):
 # ----------------------------------------------------------------------
 
 
-def test_config_import_says_it_ignored_the_yield_history(server, page, tmp_path):
+def test_config_import_says_it_ignored_the_yield_history(server, page):
     """A full backup dropped into the config importer must not lose it silently."""
     _seed_hours(server)
     result = page.evaluate(
@@ -428,6 +441,7 @@ def test_cards_sit_side_by_side_on_a_wide_screen(server, page):
 
 
 def test_cards_stack_on_a_phone(server, page):
+    """Narrow screens put the two actions one above the other."""
     _seed_hours(server)
     page.set_viewport_size(PHONE)
     _open_panel(page)
@@ -473,7 +487,7 @@ def test_nothing_overflows_horizontally(server, page, tmp_path, viewport):
     )
 
 
-def test_explainer_is_present_when_idle_and_hidden_mid_restore(server, page, tmp_path):
+def test_explainer_is_present_when_idle_and_hidden_mid_restore(page, tmp_path):
     """It fills the desktop dead space, but must not compete with the review."""
     path, _ = _write_backup(tmp_path, page)
     page.set_viewport_size(DESKTOP)
@@ -486,6 +500,7 @@ def test_explainer_is_present_when_idle_and_hidden_mid_restore(server, page, tmp
 
 
 def test_result_counts_are_laid_out_as_a_row_on_a_wide_screen(server, page, tmp_path):
+    """The counts read as a tile row, like the other overlays."""
     _seed_hours(server)
     path, _ = _write_backup(tmp_path, page)
     server.store.execute("DELETE FROM pv_yield_history")

--- a/tests/web/test_backup_ui.py
+++ b/tests/web/test_backup_ui.py
@@ -1,0 +1,402 @@
+"""
+Browser tests for the Backup & Restore panel.
+
+The REST layer is covered in ``tests/config_web/test_backup.py``.  What is checked here
+is the part no API test can see: that the panel opens from the menu, that a restore
+really does show a preview before it writes anything, and that the warnings the user is
+supposed to read are actually on screen.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _seed_hours(server, days_ago=1, hours=(8, 12)):
+    """Record measured hours so the panel has history to talk about."""
+    base = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    for hour in hours:
+        when = base.replace(hour=hour, minute=0, second=0, microsecond=0)
+        server.pv_store.insert_hourly_record(
+            timestamp=when.isoformat(),
+            date=when.strftime("%Y-%m-%d"),
+            hour=hour,
+            timeframe_id=(hour // 6) + 1,
+            real_counter_kwh=1042.5,
+            real_delta_kwh=0.83,
+            forecast_kwh=0.91,
+            local_date=when.strftime("%Y-%m-%d"),
+            local_hour=hour,
+            local_offset_minutes=0,
+        )
+
+
+def _open_menu(page):
+    """
+    Open the main dropdown.
+
+    Called directly rather than by clicking the header icon: that icon's listener is
+    attached while the dashboard boots from real optimizer output, which this harness
+    does not serve.  The dropdown itself is the real one from ``ui.js`` either way,
+    which is where the menu entry under test lives.
+    """
+    page.evaluate("() => showMainMenu('1.2.3', 'local_evopt', 3600)")
+    page.wait_for_selector("#main-dropdown-menu")
+
+
+def _open_panel(page):
+    """Open Backup & Restore the way a user does: from the main menu."""
+    _open_menu(page)
+    page.click("#main-dropdown-menu span:text-is('Backup & Restore')")
+    page.wait_for_selector("text=Create a backup")
+
+
+def _write_backup(tmp_path, page, name="backup.json"):
+    """Fetch a backup through the running app and drop it on disk for the file input."""
+    data = page.evaluate("() => fetch('api/backup/export').then(r => r.json())")
+    path = tmp_path / name
+    path.write_text(json.dumps(data))
+    return path, data
+
+
+def _choose_file(page, path):
+    page.set_input_files("#backup-restore-file", str(path))
+    page.wait_for_selector("text=Review before restoring")
+
+
+# ----------------------------------------------------------------------
+# Reaching the feature
+# ----------------------------------------------------------------------
+
+
+def test_menu_offers_backup_and_restore(page):
+    """It has to be findable where the other tools live."""
+    _open_menu(page)
+
+    assert page.is_visible("#main-dropdown-menu span:text-is('Backup & Restore')")
+    # Sits with Configuration rather than off among the external links.
+    entries = page.eval_on_selector_all(
+        "#main-dropdown-menu span", "els => els.map(e => e.textContent.trim())"
+    )
+    assert entries.index("Backup & Restore") == entries.index("Configuration") + 1
+
+
+def test_panel_opens_from_the_menu(page):
+    _open_panel(page)
+
+    assert page.is_visible("text=Create a backup")
+    assert page.is_visible("text=Restore from a backup")
+
+
+def test_panel_reports_what_the_install_holds(server, page):
+    _seed_hours(server, hours=(8, 12, 16))
+    _open_panel(page)
+
+    body = page.inner_text("#full_screen_content")
+    assert "3 hours" in body
+    assert "settings" in body
+
+
+def test_panel_warns_that_the_file_holds_secrets(page):
+    """The warning is the whole reason the export is allowed to be unmasked."""
+    _open_panel(page)
+
+    body = page.inner_text("#full_screen_content")
+    assert "plain text" in body
+    assert "password" in body.lower()
+
+
+def test_history_shows_as_unavailable_when_there_is_none(page):
+    _open_panel(page)
+
+    assert "nothing recorded yet" in page.inner_text("#full_screen_content")
+
+
+# ----------------------------------------------------------------------
+# Backing up
+# ----------------------------------------------------------------------
+
+
+def test_download_produces_a_backup_file(server, page):
+    _seed_hours(server)
+    _open_panel(page)
+
+    with page.expect_download() as info:
+        page.click("text=Download backup")
+    download = info.value
+
+    assert download.suggested_filename.startswith("eos_connect_backup_")
+    assert download.suggested_filename.endswith(".json")
+
+
+def test_downloaded_file_carries_both_datasets(server, page, tmp_path):
+    _seed_hours(server)
+    _open_panel(page)
+
+    with page.expect_download() as info:
+        page.click("text=Download backup")
+    path = tmp_path / "downloaded.json"
+    info.value.save_as(str(path))
+    data = json.loads(path.read_text())
+
+    assert data["_format"] == "eos-connect-backup"
+    assert data["battery.capacity_wh"] == 10000
+    assert len(data["pv_yield_history"]) == 2
+    assert "real_counter_kwh" not in data["pv_yield_history"][0]
+
+
+def test_deselecting_a_dataset_leaves_it_out_of_the_download(server, page, tmp_path):
+    _seed_hours(server)
+    _open_panel(page)
+    page.uncheck("#ds-backup-pv_yield_history")
+
+    with page.expect_download() as info:
+        page.click("text=Download backup")
+    path = tmp_path / "settings_only.json"
+    info.value.save_as(str(path))
+    data = json.loads(path.read_text())
+
+    assert data["_datasets"] == ["settings"]
+    assert "pv_yield_history" not in data
+
+
+# ----------------------------------------------------------------------
+# Restoring — the preview is the point
+# ----------------------------------------------------------------------
+
+
+def test_choosing_a_file_previews_instead_of_applying(server, page, tmp_path):
+    """Nothing may reach the database before the user confirms."""
+    path, _ = _write_backup(tmp_path, page)
+    server.store.set("battery.capacity_wh", 99999)
+
+    _open_panel(page)
+    _choose_file(page, path)
+
+    assert page.is_visible("text=Restore now")
+    assert server.store.get("battery.capacity_wh") == 99999
+
+
+def test_preview_names_the_settings_it_would_remove(server, page, tmp_path):
+    """A restore that silently dropped settings would be the worst kind of surprise."""
+    _, data = _write_backup(tmp_path, page)
+    del data["eos.port"]
+    path = tmp_path / "missing_key.json"
+    path.write_text(json.dumps(data))
+
+    _open_panel(page)
+    _choose_file(page, path)
+
+    body = page.inner_text("#full_screen_content")
+    assert "will be removed" in body
+    assert "eos.port" in body
+    assert server.store.has_key("eos.port")
+
+
+def test_confirming_applies_the_restore(server, page, tmp_path):
+    path, _ = _write_backup(tmp_path, page)
+    server.store.set("battery.capacity_wh", 99999)
+
+    _open_panel(page)
+    _choose_file(page, path)
+    page.click("text=Restore now")
+    page.wait_for_selector("text=Restore complete")
+
+    assert server.store.get("battery.capacity_wh") == 10000
+
+
+def test_restore_result_reports_what_happened(server, page, tmp_path):
+    _seed_hours(server)
+    path, _ = _write_backup(tmp_path, page)
+    server.store.execute("DELETE FROM pv_yield_history")
+
+    _open_panel(page)
+    _choose_file(page, path)
+    page.click("text=Restore now")
+    page.wait_for_selector("text=Restore complete")
+
+    body = page.inner_text("#full_screen_content")
+    assert "Yield hours restored" in body
+    assert len(server.pv_store.get_all_history()) == 2
+
+
+def test_cancel_discards_the_pending_restore(server, page, tmp_path):
+    path, _ = _write_backup(tmp_path, page)
+    server.store.set("battery.capacity_wh", 99999)
+
+    _open_panel(page)
+    _choose_file(page, path)
+    page.click("text=Cancel")
+    page.wait_for_selector("text=Choose backup file…")
+
+    assert server.store.get("battery.capacity_wh") == 99999
+
+
+def test_merge_mode_keeps_settings_the_file_lacks(server, page, tmp_path):
+    _, data = _write_backup(tmp_path, page)
+    del data["eos.port"]
+    path = tmp_path / "merge.json"
+    path.write_text(json.dumps(data))
+
+    _open_panel(page)
+    _choose_file(page, path)
+    page.check("#backup-mode-merge")
+    page.wait_for_function(
+        "() => !document.getElementById('full_screen_content')"
+        ".innerText.includes('will be removed')"
+    )
+    page.click("text=Restore now")
+    page.wait_for_selector("text=Restore complete")
+
+    assert server.store.has_key("eos.port")
+
+
+def test_restore_button_is_disabled_when_nothing_is_selected(page, tmp_path):
+    """Asking for nothing must not quietly restore everything."""
+    path, _ = _write_backup(tmp_path, page)
+
+    _open_panel(page)
+    _choose_file(page, path)
+    page.uncheck("#ds-restore-settings")
+    page.uncheck("#ds-restore-pv_yield_history")
+    page.wait_for_selector("text=Nothing is selected")
+
+    assert page.is_disabled("button:has-text('Restore now')")
+
+
+def test_backup_and_restore_selections_are_independent(server, page, tmp_path):
+    """Unticking a dataset under Restore must not change what Download writes."""
+    _seed_hours(server)
+    path, _ = _write_backup(tmp_path, page)
+
+    _open_panel(page)
+    _choose_file(page, path)
+    page.uncheck("#ds-restore-pv_yield_history")
+    page.wait_for_selector("#ds-restore-pv_yield_history:not(:checked)")
+
+    page.click("text=Cancel")
+    page.wait_for_selector("text=Choose backup file…")
+
+    assert page.is_checked("#ds-backup-pv_yield_history")
+    assert page.evaluate("() => backupManager.forRestore.pv_yield_history") is False
+    assert page.evaluate("() => backupManager.forBackup.pv_yield_history") is True
+
+
+def test_preview_replaces_the_backup_card(server, page, tmp_path):
+    """Mid-restore the Confirm button must not sit below an irrelevant card."""
+    path, _ = _write_backup(tmp_path, page)
+
+    _open_panel(page)
+    assert page.is_visible("text=Create a backup")
+
+    _choose_file(page, path)
+
+    assert not page.is_visible("text=Create a backup")
+    assert page.is_visible("button:has-text('Restore now')")
+
+
+# ----------------------------------------------------------------------
+# Time-shifted history
+# ----------------------------------------------------------------------
+
+
+def _stale_backup(page, tmp_path, days_ago=25):
+    """A backup whose history predates the retention window."""
+    base = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    rows = []
+    for hour in (8, 12, 16):
+        when = base.replace(hour=hour, minute=0, second=0, microsecond=0)
+        rows.append(
+            {
+                "timestamp": when.isoformat(),
+                "date": when.strftime("%Y-%m-%d"),
+                "hour": hour,
+                "timeframe_id": (hour // 6) + 1,
+                "real_delta_kwh": 0.83,
+                "forecast_kwh": 0.91,
+                "local_date": when.strftime("%Y-%m-%d"),
+                "local_hour": hour,
+                "local_offset_minutes": 0,
+            }
+        )
+    data = page.evaluate("() => fetch('api/backup/export').then(r => r.json())")
+    data["pv_yield_history"] = rows
+    path = tmp_path / "stale.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_stale_backup_preselects_time_shifting(page, tmp_path):
+    path = _stale_backup(page, tmp_path)
+
+    _open_panel(page)
+    _choose_file(page, path)
+
+    assert page.is_checked("#backup-history-seed")
+    body = page.inner_text("#full_screen_content")
+    assert "recommended" in body
+    assert "past the" in body  # the explanation of why it is offered
+
+
+def test_fresh_backup_does_not_preselect_time_shifting(server, page, tmp_path):
+    _seed_hours(server)
+    path, _ = _write_backup(tmp_path, page)
+
+    _open_panel(page)
+    _choose_file(page, path)
+
+    assert page.is_checked("#backup-history-as-is")
+    assert "Not recommended for this file" in page.inner_text("#full_screen_content")
+
+
+def test_seeded_restore_marks_the_rows(server, page, tmp_path):
+    path = _stale_backup(page, tmp_path)
+
+    _open_panel(page)
+    _choose_file(page, path)
+    page.click("text=Restore now")
+    page.wait_for_selector("text=Restore complete")
+
+    body = page.inner_text("#full_screen_content")
+    assert "History shifted" in body
+    stored = server.pv_store.get_all_history()
+    assert len(stored) == 3
+    assert {row["origin"] for row in stored} == {"seeded"}
+    assert all(row["real_counter_kwh"] is None for row in stored)
+
+
+# ----------------------------------------------------------------------
+# Config panel stays config-scoped
+# ----------------------------------------------------------------------
+
+
+def test_config_import_says_it_ignored_the_yield_history(server, page, tmp_path):
+    """A full backup dropped into the config importer must not lose it silently."""
+    _seed_hours(server)
+    result = page.evaluate(
+        """() => fetch('api/backup/export')
+            .then(r => r.json())
+            .then(b => fetch('api/config/import', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(b),
+            }))
+            .then(r => r.json())"""
+    )
+
+    assert result["ignored_datasets"] == ["pv_yield_history"]
+    assert result["imported"] > 0
+
+
+def test_preview_explains_hours_it_will_not_write(server, page, tmp_path):
+    """"2 of 6 hours" has to say where the other four went."""
+    _seed_hours(server, days_ago=1, hours=(7, 8, 9, 10, 11, 12))
+    path = _stale_backup(page, tmp_path)
+
+    _open_panel(page)
+    _choose_file(page, path)
+
+    body = page.inner_text("#full_screen_content")
+    assert "Hours already measured here" in body
+    assert "left untouched" in body


### PR DESCRIPTION
## Why

Measured PV yield — the hourly actual-vs-forecast record the auto-scaler learns
from — was not backed up and is purged on a rolling window (7 days by default).
Separately, `POST /api/config/import` wrote straight to SQL, skipping validation,
the hot-reload callbacks and restart tracking, so an imported config sat in the
database while the running interfaces kept their old values.

## What

Menu ▸ **Backup & Restore**: one file holding configuration *and* measured PV
history, each selectable on its own.

- Restoring **previews first** — it names every setting it would remove — and
  writes nothing until you confirm.
- **Replace** (default) makes config match the file exactly; **merge** keeps the
  rest.
- A backup older than the retention window can have its history **shifted into
  the window**, so scaling works from the first run instead of after a week of
  re-learning. Those rows show as `seeded` in the auto-scaling panel.
- `/api/config/export|import` are unchanged on the wire — old files still restore.

## Three deliberate choices

- **The file is flat**, not `{"settings": {…}}`. A nested file handed to an older
  build resolves zero keys and returns 200 — a silent no-op after a rollback.
  Flat, that build restores everything it recognises.
- **`real_counter_kwh` is never restored.** The auto-scaler seeds its baseline
  from the newest stored row, so a foreign meter reading would book the gap
  between two meters as one hour of yield and pin that timeframe to
  `max_scale_factor` for a full window.
- **Shifting is only offered past the retention window**, where the stored history
  and the backup provably cannot overlap. Inside it, shifted rows land on empty
  timestamps the unique index can't catch and the same day gets counted twice.

## Quality

1199 tests, up from 1077 — including 30 Playwright UI tests that skip in CI
(`requirements.txt` unchanged). New modules: `backup.py` 100%, `pv_yield_store.py`
99%. pylint 9.04 → 9.11.

Docs: new Backup & Restore sections in `docs/user-guide/configuration.html`,
`docs/advanced/index.html` and README. Worth knowing: the file holds tokens and
the inverter password in plaintext — it always did, since a masked file couldn't
restore, but that's now written down.