### PR TITLE
fix: align timeseries source with EVCC format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ EOS Connect fetches real-time and forecast data (solar, prices), runs the integr
 - **Battery and Inverter Management:** Precise charge/discharge control, grid/PV modes, and manufacturer-validated dynamic charging curves.
 - **Integration with Smart Home Platforms:** Home Assistant (MQTT auto discovery, native inverter control via service calls), OpenHAB, EVCC, and REST APIs.
 - **Dynamic Web Dashboard:** Live monitoring, manual overrides, and visualization of the optimization process.
-- **Cost Optimization:** Automatic alignment with dynamic electricity prices (Tibber, smartenergy.at, EVCC, timeseries, etc.) with configurable resolution. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#price)
+- **Cost Optimization:** Automatic alignment with dynamic electricity prices (Tibber, smartenergy.at, EVCC, timeseries, etc.) with configurable resolution. The `timeseries` source reads any HTTP or Home Assistant endpoint that publishes EVCC's `{start, end, value}` format. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#price)
 - **Dynamic Feed-In Pricing:** Optimize battery discharge for maximum profit when export prices are favorable. Switch feed-in sources live without restart via hot reload. Supports fixed, Elpris DK, EPEX Spot, and EVCC. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#price)
 - **Smart Price Prediction:** Learned grid fees and taxes for accurate planning even when future prices aren't yet available. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#energyforecast)
 - **Dynamic PV Override:** Intelligent discharge prevention during high solar production or intermittent clouds. [Learn more →](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#dyn-override)
@@ -150,7 +150,7 @@ After the wizard completes, restart EOS Connect to apply the settings.
 
 **Note:**
 - EVCC configuration must come before Inverter so you can select EVCC as your inverter controller type. If EVCC URL is not configured, the option will be greyed out in both the Inverter and PV Source selection fields.
-- PV Installations configuration is only required for location-based forecast sources (Akkudoktor, OpenMeteo, Forecast.Solar). Other sources (Default, Solcast, Victron, EVCC, Timeseries) configure their data elsewhere and do not need PV Installations defined.
+- PV Installations configuration is only required for location-based forecast sources (Akkudoktor, OpenMeteo, Forecast.Solar). Other sources (Default, Solcast, Victron, EVCC, Timeseries) configure their data elsewhere and do not need PV Installations defined. For `Timeseries`, see the [Home Assistant template snippets](https://ohAnd.github.io/EOS_connect/user-guide/configuration.html#timeseries-templates).
 
 ### Bootstrap Config (`config.yaml`)
 Only 3 infrastructure settings live in `config.yaml` — everything else is stored in the database and managed via the web UI:

--- a/docs/assets/data/config_schema.json
+++ b/docs/assets/data/config_schema.json
@@ -781,7 +781,7 @@
       "default": "http://homeassistant.local:8123/api/states/sensor.grid_prices",
       "section": "price",
       "level": "getting_started",
-      "description": "Data source URL. For Home Assistant: http://[HA_HOST]:[PORT]/api/states/[sensor_entity]. For HTTP servers: endpoint URL returning JSON timeseries. Must return JSON array with {start, end, value} format (values in EUR/Wh).",
+      "description": "Data source URL. For Home Assistant: http://[HA_HOST]:[PORT]/api/states/[sensor_entity]. For HTTP servers: endpoint URL returning JSON timeseries. Must return a JSON array in EVCC's {start, end, value} format; 'end' is optional. The unit of 'value' is set by price.value_unit.",
       "labels": [],
       "help_url": "configuration.html#price-sources",
       "validation": {
@@ -814,6 +814,30 @@
         ],
         "price.use_ha_central_data_source": [
           false
+        ]
+      },
+      "hot_reload": true,
+      "display_group": "Grid Price Provider"
+    },
+    {
+      "key": "price.value_unit",
+      "type": "select",
+      "default": "EUR/kWh",
+      "section": "price",
+      "level": "getting_started",
+      "description": "Unit of the 'value' field in the timeseries. Default matches EVCC's /api/tariff/grid and the common Home Assistant price integrations (EUR/kWh). Pick EUR/Wh only for a source that already delivers the internal unit.",
+      "labels": [],
+      "help_url": "configuration.html#price-sources",
+      "validation": {
+        "choices": [
+          "EUR/kWh",
+          "ct/kWh",
+          "EUR/Wh"
+        ]
+      },
+      "depends_on": {
+        "price.source": [
+          "timeseries"
         ]
       },
       "hot_reload": true,
@@ -1569,7 +1593,7 @@
       "default": "http://homeassistant.local:8123/api/states/sensor.pv_forecast",
       "section": "pv_forecast_source",
       "level": "getting_started",
-      "description": "Data source URL. For Home Assistant: http://[HA_HOST]:[PORT]/api/states/[sensor_entity]. For HTTP servers: endpoint URL returning JSON timeseries. Must return JSON array with {start, end, value} format.",
+      "description": "Data source URL. For Home Assistant: http://[HA_HOST]:[PORT]/api/states/[sensor_entity]. For HTTP servers: endpoint URL returning JSON timeseries. Must return a JSON array in EVCC's {start, end, value} format; 'end' is optional. The unit of 'value' is set by pv_forecast_source.value_unit.",
       "labels": [],
       "help_url": "configuration.html#pv-forecast-sources",
       "validation": {
@@ -1602,6 +1626,31 @@
         ],
         "pv_forecast_source.use_ha_central_data_source": [
           false
+        ]
+      },
+      "hot_reload": true,
+      "display_group": "Provider"
+    },
+    {
+      "key": "pv_forecast_source.value_unit",
+      "type": "select",
+      "default": "W",
+      "section": "pv_forecast_source",
+      "level": "getting_started",
+      "description": "Unit of the 'value' field in the timeseries. Default matches EVCC's solar forecast and the usual Home Assistant PV sensors, which report power (W) per slot. Pick Wh/kWh for a source that reports energy per slot instead.",
+      "labels": [],
+      "help_url": "configuration.html#pv-forecast-sources",
+      "validation": {
+        "choices": [
+          "W",
+          "kW",
+          "Wh",
+          "kWh"
+        ]
+      },
+      "depends_on": {
+        "pv_forecast_source.source": [
+          "timeseries"
         ]
       },
       "hot_reload": true,

--- a/docs/user-guide/configuration.html
+++ b/docs/user-guide/configuration.html
@@ -4782,28 +4782,55 @@ price:
                     <!-- Timeseries Data Source Guide -->
                     <div class="content-section" id="timeseries-guide">
                         <h2><i class="fas fa-stream"></i> Unified Timeseries Data Source Guide</h2>
-                        <p>EOS Connect supports a flexible <strong>timeseries</strong> source for both
-                            <strong>electricity prices</strong> and <strong>PV forecasts</strong>. This unified approach
-                            allows you to fetch data from Home Assistant, custom HTTP APIs, or any endpoint that returns
-                            timeseries data in a standard format.
+                        <p>EOS Connect supports a unified <strong>timeseries</strong> source for both
+                            <strong>electricity prices</strong> and <strong>PV forecasts</strong>. It fetches data from
+                            Home Assistant, custom HTTP APIs, or any endpoint that returns timeseries data in the
+                            expected format.
+                        </p>
+                        <p><strong>The expected format is EVCC's format.</strong> That is deliberate: it is the format
+                            you most likely already have. An EVCC endpoint such as
+                            <code>/api/tariff/grid</code> can be used as-is, and a Home Assistant template sensor
+                            written to feed EVCC works unchanged. Home Assistant is the <em>transport</em> here
+                            (state API, entity attributes, bearer token) — the <em>format</em> comes from EVCC.
+                        </p>
+                        <p>EOS Connect accepts exactly this one format and does not try to guess foreign attribute
+                            names. Where an integration uses different names, you shape it once with a Home Assistant
+                            template sensor — see
+                            <a href="#timeseries-templates">Home Assistant Template Snippets</a> for ready-made
+                            examples.
                         </p>
 
+                        <div class="alert alert-warning">
+                            <strong><i class="fas fa-triangle-exclamation"></i> Changed in this release:</strong>
+                            The unit of <code>value</code> now matches what EVCC and the common Home Assistant
+                            integrations actually deliver: <strong>EUR/kWh</strong> for prices and <strong>W</strong>
+                            for PV. Previously EOS Connect expected EUR/Wh and Wh-per-slot — units no real source
+                            provides.
+                            <br><br>
+                            If you already run a <code>timeseries</code> source, check it after updating: set
+                            <code>price.value_unit</code> / <code>pv_forecast_source.value_unit</code> to whatever your
+                            source actually delivers. Selecting <code>EUR/Wh</code> resp. <code>Wh</code> restores the
+                            previous behaviour exactly. Use
+                            <a href="#timeseries-testing">Test connection</a> to see the resulting values before
+                            saving.
+                        </div>
+
                         <h3>Timeseries Data Format</h3>
-                        <p>The timeseries source expects JSON data in this standard format:</p>
+                        <p>The timeseries source expects JSON data in this format:</p>
                         <div
                             style="background: rgb(78, 78, 78); padding: 12px; border-radius: 8px; overflow-x: auto; margin: 1rem 0;">
                             <pre
                                 style="margin: 0; font-size: 0.85rem; font-family: 'Courier New', monospace; color: #e0e0e0;">{
   "data": [
     {
-      "start": "2024-06-12T14:00:00Z",
-      "end": "2024-06-12T15:00:00Z",
-      "value": 0.25
+      "start": "2026-08-23T00:00:00+02:00",
+      "end": "2026-08-23T00:15:00+02:00",
+      "value": 0.3811
     },
     {
-      "start": "2024-06-12T15:00:00Z",
-      "end": "2024-06-12T16:00:00Z",
-      "value": 0.28
+      "start": "2026-08-23T00:15:00+02:00",
+      "end": "2026-08-23T00:30:00+02:00",
+      "value": 0.3727
     }
   ]
 }</pre>
@@ -4817,28 +4844,74 @@ price:
                             </tr>
                             <tr>
                                 <td><strong>start</strong></td>
-                                <td>Start timestamp of the timeslot</td>
-                                <td>ISO8601 (e.g., "2024-06-12T14:00:00Z" or Unix timestamp)</td>
+                                <td><strong>Required.</strong> Start timestamp of the timeslot. Always include the UTC
+                                    offset — a timestamp without one is read as local time, which silently shifts every
+                                    slot.</td>
+                                <td>ISO8601 (e.g., "2026-08-23T00:00:00+02:00" or "…Z"), or Unix timestamp</td>
                             </tr>
                             <tr>
                                 <td><strong>end</strong></td>
-                                <td>End timestamp of the timeslot</td>
+                                <td><strong>Optional.</strong> If absent, EOS Connect derives it from the next entry's
+                                    <code>start</code> (and the last entry from the preceding interval), so a source
+                                    that only publishes start times is accepted.</td>
                                 <td>ISO8601 or Unix timestamp</td>
                             </tr>
                             <tr>
                                 <td><strong>value</strong></td>
-                                <td><strong>For Prices:</strong> Price in EUR/Wh (e.g., 0.25 for 25 ct/kWh)<br>
-                                    <strong>For PV:</strong> Generated power in Wh for the timeslot
+                                <td><strong>Required.</strong><br>
+                                    <strong>For Prices:</strong> price per slot, by default in <strong>EUR/kWh</strong>
+                                    (e.g. 0.3811 for 38.11&nbsp;ct/kWh) — as EVCC's <code>rates</code> deliver it.<br>
+                                    <strong>For PV:</strong> generated power per slot, by default in <strong>W</strong> —
+                                    as EVCC's solar forecast delivers it.<br>
+                                    Use <code>value_unit</code> if your source uses a different unit.
                                 </td>
                                 <td>Number (float)</td>
                             </tr>
                         </table>
 
+                        <h3>Value Unit</h3>
+                        <p>If your source does not use the default unit, select the matching one instead of building a
+                            conversion into your template:</p>
+                        <table>
+                            <tr>
+                                <th>Setting</th>
+                                <th>Options</th>
+                                <th>Default</th>
+                            </tr>
+                            <tr>
+                                <td><code>price.value_unit</code></td>
+                                <td><code>EUR/kWh</code>, <code>ct/kWh</code>, <code>EUR/Wh</code></td>
+                                <td><code>EUR/kWh</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>pv_forecast_source.value_unit</code></td>
+                                <td><code>W</code>, <code>kW</code>, <code>Wh</code>, <code>kWh</code></td>
+                                <td><code>W</code></td>
+                            </tr>
+                        </table>
+                        <div class="alert alert-info">
+                            <strong><i class="fas fa-info-circle"></i> Power vs. energy for PV:</strong>
+                            <code>W</code> and <code>kW</code> are power readings and are integrated over the slot
+                            length — 4000&nbsp;W across a 15-minute slot becomes 1000&nbsp;Wh. <code>Wh</code> and
+                            <code>kWh</code> are taken as the energy of that slot directly. Picking the wrong one is a
+                            factor-of-four error on 15-minute data, so use
+                            <a href="#timeseries-testing">Test connection</a> if you are unsure.
+                        </div>
+
                         <div class="alert alert-info">
                             <strong><i class="fas fa-info-circle"></i> Time Resolution:</strong> EOS Connect
-                            auto-detects whether the timeseries is 15-minute (900s) or hourly (3600s) based on the
-                            timestamp differences. It automatically converts 15-minute data to hourly by averaging 4
-                            consecutive values.
+                            auto-detects whether the timeseries is 15-minute (900s) or hourly (3600s) from the
+                            timestamp differences. 15-minute data is converted to hourly automatically — prices are
+                            averaged, PV energy is summed. An hourly source cannot serve a system configured for
+                            15-minute slots; the connection test reports that rather than letting it fail at runtime.
+                        </div>
+
+                        <div class="alert alert-info">
+                            <strong><i class="fas fa-info-circle"></i> All-or-nothing parsing:</strong> if a single
+                            entry is malformed — a <code>null</code> value, an unparseable timestamp, a missing field —
+                            the whole payload is rejected and EOS Connect keeps using the last good data. Skipping just
+                            the bad entry would shift every following hourly price by one slot, which is not visible
+                            anywhere in the UI. The log names the offending entry by index.
                         </div>
 
                         <h3>Home Assistant Integration</h3>
@@ -4949,9 +5022,106 @@ price:
 }</pre>
                         </div>
 
-                        <h3>Testing Your Timeseries Configuration</h3>
-                        <p>Use the built-in connectivity test to validate your timeseries configuration before enabling
-                            it.</p>
+                        <h3 id="timeseries-templates">Home Assistant Template Snippets</h3>
+                        <p>Home Assistant integrations name their attributes differently — Tibber and EPEX use
+                            <code>start_time</code> and <code>price_per_kwh</code>, Solcast uses
+                            <code>period_start</code> and <code>pv_estimate</code>. EOS Connect does not guess these
+                            names. Instead you publish one template sensor in the expected format; adapting to a
+                            different provider then means editing the template, not reconfiguring EOS Connect.</p>
+                        <p>Because <code>end</code> is derived automatically, the templates only need
+                            <code>start</code> and <code>value</code>.</p>
+
+                        <h4>Prices: Tibber Price Information / EPEX Spot (HACS)</h4>
+                        <p>Both provide a <code>data</code> attribute with <code>start_time</code> and
+                            <code>price_per_kwh</code> (EUR/kWh):</p>
+                        <div
+                            style="background: rgb(78, 78, 78); padding: 12px; border-radius: 8px; overflow-x: auto; margin: 1rem 0;">
+                            <pre
+                                style="margin: 0; font-size: 0.85rem; font-family: 'Courier New', monospace; color: #e0e0e0;">template:
+  - trigger:
+      - platform: time_pattern
+        minutes: "/5"
+    sensor:
+      - name: eos_grid_prices
+        state: "ok"
+        attributes:
+          data: &gt;
+            {% set src = state_attr('sensor.YOUR_PRICE_SENSOR', 'data') %}
+            [
+            {%- for e in src %}
+              {"start": "{{ e.start_time }}", "value": {{ e.price_per_kwh }}}
+              {%- if not loop.last %},{% endif %}
+            {%- endfor %}
+            ]</pre>
+                        </div>
+                        <p>Then set <code>price.data_url</code> to
+                            <code>http://homeassistant.local:8123/api/states/sensor.eos_grid_prices</code>,
+                            <code>price.data_path</code> to <code>attributes.data</code> and
+                            <code>price.value_unit</code> to <code>EUR/kWh</code>.</p>
+
+                        <h4>Prices: Tibber core integration (via action)</h4>
+                        <p>The built-in Tibber integration no longer exposes the price list as a sensor attribute. Its
+                            action response is keyed by address and uses <code>start_time</code> and
+                            <code>price</code>, so fetch it in an automation and feed the result into a trigger-based
+                            template sensor built the same way as above:</p>
+                        <div
+                            style="background: rgb(78, 78, 78); padding: 12px; border-radius: 8px; overflow-x: auto; margin: 1rem 0;">
+                            <pre
+                                style="margin: 0; font-size: 0.85rem; font-family: 'Courier New', monospace; color: #e0e0e0;">{% set src = prices['YOUR_ADDRESS'] %}
+[
+{%- for e in src %}
+  {"start": "{{ e.start_time }}", "value": {{ e.price }}}
+  {%- if not loop.last %},{% endif %}
+{%- endfor %}
+]</pre>
+                        </div>
+
+                        <h4>PV forecast: Solcast</h4>
+                        <p>Based on the template shared by <strong>@bennobiber</strong> in
+                            <a href="https://github.com/ohAnd/EOS_connect/discussions/214" target="_blank"
+                                rel="noopener">discussion #214</a>, which already feeds EVCC. <code>value</code> stays
+                            in W, matching the default <code>pv_forecast_source.value_unit</code>.</p>
+                        <div
+                            style="background: rgb(78, 78, 78); padding: 12px; border-radius: 8px; overflow-x: auto; margin: 1rem 0;">
+                            <pre
+                                style="margin: 0; font-size: 0.85rem; font-family: 'Courier New', monospace; color: #e0e0e0;">template:
+  - trigger:
+      - platform: time_pattern
+        minutes: "/5"
+    sensor:
+      - name: eos_pv_forecast
+        state: "ok"
+        attributes:
+          data: &gt;
+            {% set today = state_attr('sensor.solcast_pv_forecast_forecast_today', 'detailedForecast') %}
+            {% set tomorrow = state_attr('sensor.solcast_pv_forecast_forecast_tomorrow', 'detailedForecast') %}
+            {% set all = (today if today else []) + (tomorrow if tomorrow else []) %}
+            [
+            {%- for e in all %}
+              {"start": "{{ e.period_start.isoformat() }}", "value": {{ (e.pv_estimate * 1000) | round(0) }}}
+              {%- if not loop.last %},{% endif %}
+            {%- endfor %}
+            ]</pre>
+                        </div>
+                        <div class="alert alert-warning">
+                            <strong><i class="fas fa-triangle-exclamation"></i> Use
+                                <code>.isoformat()</code>, not <code>| timestamp_utc</code>:</strong>
+                            <code>timestamp_utc</code> renders UTC wall-clock time <em>without</em> an offset. EOS
+                            Connect then reads it as local time and every slot is shifted by your UTC offset.
+                            <code>period_start.isoformat()</code> keeps the offset. If you already use such a template
+                            for EVCC, adjust this one line.
+                        </div>
+
+                        <h3 id="timeseries-testing">Testing Your Timeseries Configuration</h3>
+                        <p>Use <strong>Test connection</strong> in the configuration UI, next to the timeseries
+                            settings. It fetches the endpoint, resolves <code>data_path</code>, parses the payload and
+                            shows the first slots <em>converted into the unit the schedule uses</em> — so a wrong
+                            <code>value_unit</code> shows up as an absurd number before you save, rather than hours
+                            later in the schedule. It tests the values currently in the form, including unsaved ones.
+                        </p>
+                        <p>The same check runs automatically when you save a timeseries setting; a hard failure blocks
+                            the save and is reported on the field that caused it, while a plausibility warning does not
+                            block.</p>
 
                         <p><strong>HTTP Request:</strong></p>
                         <div
@@ -4961,31 +5131,44 @@ price:
 Content-Type: application/json
 
 {
-  "source": "price",
-  "data_url": "http://homeassistant.local:8123/api/states/sensor.grid_prices",
-  "data_path": "attributes.data",
-  "data_token": "eyJhbGciOiJIUzI1NiI..."
+  "domain": "price",
+  "price.data_url": "http://homeassistant.local:8123/api/states/sensor.eos_grid_prices",
+  "price.data_path": "attributes.data",
+  "price.value_unit": "EUR/kWh"
 }</pre>
                         </div>
+                        <p>All keys are optional — anything omitted falls back to the stored configuration.
+                            <code>domain</code> is <code>price</code> (default) or <code>pv</code>.</p>
 
                         <p><strong>Response (Success):</strong></p>
                         <div
                             style="background: rgb(78, 78, 78); padding: 12px; border-radius: 8px; overflow-x: auto; margin: 1rem 0;">
                             <pre
                                 style="margin: 0; font-size: 0.85rem; font-family: 'Courier New', monospace; color: #28a745;">{
-  "success": true,
-  "message": "Successfully fetched 24 price values",
-  "sample_count": 24,
-  "first_entry": {
-    "start": "2024-06-12T14:00:00Z",
-    "end": "2024-06-12T15:00:00Z",
-    "value": 0.25
-  },
-  "last_entry": {
-    "start": "2024-06-13T14:00:00Z",
-    "end": "2024-06-13T15:00:00Z",
-    "value": 0.22
-  }
+  "ok": true,
+  "entry_count": 192,
+  "resolution_seconds": 900,
+  "value_unit": "EUR/kWh",
+  "slots": [
+    {"start": "2026-08-23T00:00:00+02:00", "end": "2026-08-23T00:15:00+02:00",
+     "value": 38.11, "unit": "ct/kWh"}
+  ],
+  "warnings": []
+}</pre>
+                        </div>
+
+                        <p><strong>Response (Format mismatch):</strong> the message names the fields the payload
+                            actually contained, so you can see what to map in your template:</p>
+                        <div
+                            style="background: rgb(78, 78, 78); padding: 12px; border-radius: 8px; overflow-x: auto; margin: 1rem 0;">
+                            <pre
+                                style="margin: 0; font-size: 0.85rem; font-family: 'Courier New', monospace; color: #ff6b6b;">{
+  "ok": false,
+  "field": "price.data_path",
+  "error": "missing required field 'start' in the first entry (available fields:
+            'start_time', 'price_per_kwh'). The expected format is {start, end, value}
+            - shape the source with a Home Assistant template sensor, see
+            configuration.html#timeseries-templates"
 }</pre>
                         </div>
 
@@ -5006,10 +5189,12 @@ Content-Type: application/json
                         <p>All timeseries configuration fields support hot-reload — changes take effect immediately
                             without restarting the application:</p>
                         <ul>
-                            <li><code>price.data_url</code>, <code>price.data_path</code>, <code>price.data_token</code>
+                            <li><code>price.data_url</code>, <code>price.data_path</code>,
+                                <code>price.data_token</code>, <code>price.value_unit</code>
                             </li>
                             <li><code>pv_forecast_source.data_url</code>, <code>pv_forecast_source.data_path</code>,
-                                <code>pv_forecast_source.data_token</code>
+                                <code>pv_forecast_source.data_token</code>,
+                                <code>pv_forecast_source.value_unit</code>
                             </li>
                         </ul>
                         <p>Changes are applied within 1-2 seconds on the next update cycle.</p>

--- a/src/config_web/api.py
+++ b/src/config_web/api.py
@@ -12,7 +12,9 @@ import logging
 import re
 from flask import Blueprint, jsonify, request as flask_request, Response
 
+from .hot_reload import _coerce_bool
 from .migration import _flatten_config
+from .timeseries_probe import probe
 
 logger = logging.getLogger("__main__")
 
@@ -632,24 +634,61 @@ def _check_dependencies(data: dict) -> list[dict]:
     return dependencies
 
 
-def _check_timeseries_preflight(data: dict) -> list[dict]:
+# Config keys that make a timeseries probe worthwhile. Saving anything else must not
+# trigger a network round-trip, so an unrelated setting change stays fast and cannot be
+# blocked by a momentarily unreachable endpoint.
+_TIMESERIES_PROBE_TRIGGERS = {
+    "price": {
+        "price.source",
+        "price.data_url",
+        "price.data_path",
+        "price.data_token",
+        "price.value_unit",
+        "price.use_ha_central_data_source",
+        "price.ha_sensor_name",
+    },
+    "pv": {
+        "pv_forecast_source.source",
+        "pv_forecast_source.data_url",
+        "pv_forecast_source.data_path",
+        "pv_forecast_source.data_token",
+        "pv_forecast_source.value_unit",
+        "pv_forecast_source.use_ha_central_data_source",
+        "pv_forecast_source.ha_sensor_name",
+    },
+}
+
+# The shared data source only feeds a domain that opted into central mode, so it may
+# only trigger that domain's probe. Listing it unconditionally would let an unreachable
+# PV endpoint block an unrelated edit of the Home Assistant URL.
+_CENTRAL_DATA_SOURCE_TRIGGERS = {"data_source.url", "data_source.access_token"}
+
+_TIMESERIES_DOMAIN_SECTIONS = {
+    "price": ("price", "sensor.grid_prices", "EUR/kWh"),
+    "pv": ("pv_forecast_source", "sensor.pv_forecast", "W"),
+}
+
+
+def _effective_value_getter(data: dict):
     """
-    Check if we're modifying a timeseries config and validate the sensor exists.
-    Returns list of error dicts if validation fails.
+    Build a resolver for "value after this update would be applied".
+
+    Resolution order is update body → store → merged config. The store has to come
+    before the merged config: ``merger._apply_central_ha_data_source`` overwrites
+    ``<section>.data_url`` / ``data_token`` with values derived from the central data
+    source, so reading the merged config would hand back a derived HA URL even for a
+    request that is switching central mode off. The store still holds what the user
+    actually entered. The merged config remains the last resort so schema defaults are
+    picked up for keys never written.
     """
-    errors = []
     current_config = _module.get_config()
 
-    # Helper: get effective value (from update data or current config)
     def get_value(key):
         if key in data:
             return data[key]
-        # For data_source keys, check store directly
-        # (data_source is excluded from merged config)
-        if key.startswith("data_source."):
-            store_val = _store.get(key)
-            if store_val is not None:
-                return store_val
+        store_val = _store.get(key)
+        if store_val is not None:
+            return store_val
         parts = key.split(".")
         val = current_config
         for part in parts:
@@ -659,74 +698,221 @@ def _check_timeseries_preflight(data: dict) -> list[dict]:
                 return None
         return val
 
-    # Check if we're modifying price timeseries config
-    price_source = get_value("price.source")
-    if price_source == "timeseries":
-        use_ha_central = get_value("price.use_ha_central_data_source")
-        if use_ha_central:
-            # Central HA mode: sensor name + data_source config
-            ha_sensor_name = get_value("price.ha_sensor_name")
-            data_source_url = get_value("data_source.url")
-            data_source_token = get_value("data_source.access_token")
+    return get_value
 
-            if (
-                ha_sensor_name and data_source_url and data_source_token
-            ):
-                # Try to fetch the sensor from Home Assistant
-                ha_url = (
-                    f"{data_source_url.rstrip('/')}/api/states/{ha_sensor_name}"
-                )
-                try:
-                    import requests
-                    response = requests.get(
-                        ha_url,
-                        headers={"Authorization": f"Bearer {data_source_token}"},
-                        timeout=5
-                    )
-                    if response.status_code == 404:
-                        errors.append({
-                            "key": "price.ha_sensor_name",
-                            "error": (
-                                f"Sensor '{ha_sensor_name}' not found in "
-                                "Home Assistant"
-                            )
-                        })
-                    elif response.status_code != 200:
-                        errors.append({
-                            "key": "price.ha_sensor_name",
-                            "error": (
-                                f"Home Assistant error {response.status_code}: "
-                                f"{response.reason}"
-                            )
-                        })
-                except requests.exceptions.HTTPError as e:
-                    if hasattr(e, 'response') and e.response is not None:
-                        if e.response.status_code == 404:
-                            errors.append({
-                                "key": "price.ha_sensor_name",
-                                "error": (
-                                    f"Sensor '{ha_sensor_name}' not found in "
-                                    "Home Assistant"
-                                )
-                            })
-                        else:
-                            errors.append({
-                                "key": "price.ha_sensor_name",
-                                "error": (
-                                    f"Home Assistant error "
-                                    f"{e.response.status_code}: "
-                                    f"{e.response.reason}"
-                                )
-                            })
-                except Exception as e:
-                    # Log detailed error server-side only (not exposed to client)
-                    logger.error("Home Assistant connection error: %s", str(e), exc_info=True)
-                    errors.append({
-                        "key": "price.ha_sensor_name",
-                        "error": "Failed to connect to Home Assistant. Check configuration and logs."
-                    })
+
+def _raw_value_getter(data: dict):
+    """
+    Resolve a key without consulting the merged config.
+
+    ``merger._apply_central_ha_data_source`` overwrites ``<section>.data_url`` and
+    ``data_token`` with values derived from the shared data source. For a request that
+    turns central mode off, the merged config would therefore hand back the derived HA
+    URL rather than the user's own — and the probe would happily green-light a config
+    that 401s at runtime. Falling back to the schema default instead keeps this
+    resolution honest for exactly those two keys.
+    """
+    def get_raw(key):
+        if key in data:
+            return data[key]
+        store_val = _store.get(key)
+        if store_val is not None:
+            return store_val
+        field_def = _schema.get(key)
+        return field_def.default if field_def else None
+
+    return get_raw
+
+
+def _resolve_timeseries_config(domain: str, data: dict, get_value) -> dict:
+    """
+    Resolve the connection details a timeseries probe needs for one domain.
+
+    Mirrors merger._apply_central_ha_data_source: in central mode the URL is built
+    from the shared data_source plus the sensor entity, so the probe tests exactly
+    what the interface will later fetch.
+    """
+    section, default_sensor, default_unit = _TIMESERIES_DOMAIN_SECTIONS[domain]
+    get_raw = _raw_value_getter(data)
+
+    def merger_style(key, default):
+        """Default only on absence, as the merger's dict.get(key, default) does."""
+        value = get_value(key)
+        return default if value is None else value
+
+    # Coerced, not truthiness-tested: pre-flight runs before _coerce_value, so a REST
+    # client sending the string "false" would otherwise take the central-HA branch.
+    if _coerce_bool(get_value(f"{section}.use_ha_central_data_source")):
+        ds_url = get_value("data_source.url") or ""
+        sensor = merger_style(f"{section}.ha_sensor_name", default_sensor)
+        # Built exactly as merger._apply_central_ha_data_source builds it — including
+        # the absence of rstrip and the empty-string passthrough — so the probe can
+        # never pass on a URL the running interface would fetch differently.
+        data_url = f"{ds_url}/api/states/{sensor}" if ds_url else ""
+        data_token = get_value("data_source.access_token") or ""
+        sensor_field = f"{section}.ha_sensor_name"
+        resource_label = sensor or f"{section}.ha_sensor_name"
+    else:
+        data_url = get_raw(f"{section}.data_url") or ""
+        data_token = get_raw(f"{section}.data_token") or ""
+        sensor_field = f"{section}.data_url"
+        resource_label = data_url
+
+    return {
+        "data_url": data_url,
+        "data_path": get_value(f"{section}.data_path") or "attributes.data",
+        "data_token": data_token,
+        "value_unit": get_value(f"{section}.value_unit") or default_unit,
+        "sensor_field": sensor_field,
+        "resource_label": resource_label,
+    }
+
+
+def _effective_time_frame_base(get_value) -> int:
+    """
+    The slot length the interfaces will actually run at.
+
+    Mirrors the coercion in eos_connect.py: 15-minute slots are only honoured for the
+    EVopt backends and otherwise fall back to hourly. Using the stored value verbatim
+    would make the probe reject an hourly source for a system that in fact runs
+    hourly.
+    """
+    try:
+        time_frame_base = int(get_value("eos.time_frame") or 3600)
+    except (TypeError, ValueError):
+        return 3600
+
+    if time_frame_base not in (900, 3600):
+        return 3600
+    if time_frame_base == 900 and get_value("eos.source") not in (
+        "evopt",
+        "local_evopt",
+    ):
+        return 3600
+    return time_frame_base
+
+
+def _installed_pv_power_w(config: dict) -> float:
+    """Total configured array power, or 0 when no PV installations are defined."""
+    total = 0.0
+    for entry in config.get("pv_forecast") or []:
+        if isinstance(entry, dict):
+            try:
+                total += float(entry.get("power", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+    return total
+
+
+def _probe_timeseries_domain(domain: str, data: dict, get_value) -> dict:
+    """Run the probe for one domain using the effective (post-update) config."""
+    resolved = _resolve_timeseries_config(domain, data, get_value)
+    config = _module.get_config() or {}
+    time_zone = config.get("time_zone", "UTC")
+    time_frame_base = _effective_time_frame_base(get_value)
+    result = probe(
+        domain,
+        resolved["data_url"],
+        resolved["data_path"],
+        resolved["data_token"],
+        resolved["value_unit"],
+        time_zone,
+        resource_label=resolved["resource_label"],
+        time_frame_base=time_frame_base,
+        installed_power_w=_installed_pv_power_w(config) if domain == "pv" else 0,
+    )
+    # In central-HA mode the actionable field is the sensor name, not the derived URL.
+    if not result.get("ok") and result.get("field", "").endswith(".data_url"):
+        result["field"] = resolved["sensor_field"]
+    return result
+
+
+def _check_timeseries_preflight(data: dict) -> list[dict]:
+    """
+    Validate timeseries sources before saving.
+
+    Covers price and PV, and both connection modes. Beyond reachability this also
+    resolves the configured data_path and parses the payload, so a format or unit
+    mistake is reported against the field that caused it instead of surfacing hours
+    later as an implausible schedule. Warnings (e.g. an odd price level) never block
+    the save — only hard failures do.
+    """
+    errors = []
+    get_value = _effective_value_getter(data)
+
+    for domain, (section, _sensor, _unit) in _TIMESERIES_DOMAIN_SECTIONS.items():
+        if get_value(f"{section}.source") != "timeseries":
+            continue
+
+        own_keys_touched = bool(_TIMESERIES_PROBE_TRIGGERS[domain] & data.keys())
+        central_touched = bool(
+            _CENTRAL_DATA_SOURCE_TRIGGERS & data.keys()
+        ) and _coerce_bool(get_value(f"{section}.use_ha_central_data_source"))
+        if not (own_keys_touched or central_touched):
+            continue
+
+        result = _probe_timeseries_domain(domain, data, get_value)
+        if result.get("ok"):
+            continue
+
+        if not own_keys_touched:
+            # Only the shared data source changed. The user is not editing this
+            # domain, so a failure here is collateral — a deleted PV sensor must not
+            # make it impossible to rotate the Home Assistant token.
+            logger.info(
+                "[ConfigAPI] Timeseries pre-flight for the %s source failed while "
+                "the shared data source changed: %s",
+                domain,
+                result.get("error"),
+            )
+            continue
+
+        if result.get("transport"):
+            # The endpoint did not answer at all. That is not necessarily a bad
+            # configuration — it is also what a source being briefly down looks like,
+            # and what switching `source` to timeseries before filling in the URL
+            # looks like. Blocking the whole PUT on it would hold every other key in
+            # the request hostage to a 10s timeout, so record it and let the save
+            # proceed; the running interface reports it on the next cycle.
+            logger.info(
+                "[ConfigAPI] Timeseries pre-flight could not reach the %s source: %s",
+                domain,
+                result.get("error"),
+            )
+            continue
+
+        errors.append(
+            {
+                "key": result.get("field", f"{section}.data_url"),
+                "error": result.get("error", "Timeseries check failed."),
+            }
+        )
 
     return errors
+
+
+@config_bp.route("/test-timeseries", methods=["POST"])
+def test_timeseries():
+    """
+    Probe a timeseries data source and report what it yields.
+
+    Body: optional flat dot-notation keys (as for PUT /), so the UI can test values
+    the user has typed but not yet saved. Anything absent falls back to the stored
+    config. ``domain`` selects "price" (default) or "pv".
+
+    Returns 200 with the probe result in both the success and the failure case — a
+    source that does not answer is a finding, not a server error.
+    """
+    data = flask_request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "Request body must be a JSON object"}), 400
+
+    domain = data.pop("domain", "price")
+    if domain not in _TIMESERIES_DOMAIN_SECTIONS:
+        return jsonify({"error": "domain must be 'price' or 'pv'"}), 400
+
+    get_value = _effective_value_getter(data)
+    return jsonify(_probe_timeseries_domain(domain, data, get_value)), 200
 
 
 def _validate_price_arrays(data: dict) -> list[dict]:

--- a/src/config_web/hot_reload.py
+++ b/src/config_web/hot_reload.py
@@ -17,6 +17,7 @@ Supported fields (Price data source reload — immediate data fetch):
 - ``price.data_url``  (triggers immediate fetch when source=timeseries)
 - ``price.data_path``  (triggers immediate fetch when source=timeseries)
 - ``price.data_token``  (triggers immediate fetch when source=timeseries)
+- ``price.value_unit``  (triggers immediate fetch when source=timeseries)
 - ``price.use_ha_central_data_source``  (triggers immediate fetch when source=timeseries)
 - ``price.ha_sensor_name``  (triggers immediate fetch when source=timeseries)
 
@@ -71,12 +72,13 @@ _PRICE_FIELD_MAP = {
     "price.feed_in_price": ("feed_in_tariff_price", float),
 }
 
-# Price data source fields that require reload (timeseries URL/path/token)
+# Price data source fields that require reload (timeseries URL/path/token/unit)
 _PRICE_DATA_FIELDS = {
     "price.source",
     "price.data_url",
     "price.data_path",
     "price.data_token",
+    "price.value_unit",
     "price.use_ha_central_data_source",
     "price.ha_sensor_name",
 }
@@ -709,6 +711,7 @@ class HotReloadAdapter:
             self._price.data_url = price_config.get("data_url", "").strip()
             self._price.data_path = price_config.get("data_path", "attributes.data").strip()
             self._price.data_token = price_config.get("data_token", "").strip()
+            self._price.value_unit = price_config.get("value_unit", "EUR/kWh").strip()
             self._applied_keys.append(key)
             # Determine if we should trigger immediate fetch
             # Fetch if new source is timeseries (either switching TO it or already using

--- a/src/config_web/schema.py
+++ b/src/config_web/schema.py
@@ -720,7 +720,8 @@ _ALL_FIELDS: list[FieldDef] = [
             "Data source URL. For Home Assistant: "
             "http://[HA_HOST]:[PORT]/api/states/[sensor_entity]. "
             "For HTTP servers: endpoint URL returning JSON timeseries. "
-            "Must return JSON array with {start, end, value} format (values in EUR/Wh)."
+            "Must return a JSON array in EVCC's {start, end, value} format; "
+            "'end' is optional. The unit of 'value' is set by price.value_unit."
         ),
         help_url="configuration.html#price-sources",
         depends_on={
@@ -747,6 +748,24 @@ _ALL_FIELDS: list[FieldDef] = [
             "price.source": ["timeseries"],
             "price.use_ha_central_data_source": [False],
         },
+        hot_reload=True,
+        display_group="Grid Price Provider",
+    ),
+    FieldDef(
+        key="price.value_unit",
+        field_type="select",
+        default="EUR/kWh",
+        section="price",
+        level="getting_started",
+        description=(
+            "Unit of the 'value' field in the timeseries. Default matches EVCC's "
+            "/api/tariff/grid and the common Home Assistant price integrations "
+            "(EUR/kWh). Pick EUR/Wh only for a source that already delivers the "
+            "internal unit."
+        ),
+        help_url="configuration.html#price-sources",
+        validation={"choices": ["EUR/kWh", "ct/kWh", "EUR/Wh"]},
+        depends_on={"price.source": ["timeseries"]},
         hot_reload=True,
         display_group="Grid Price Provider",
     ),
@@ -1244,7 +1263,9 @@ _ALL_FIELDS: list[FieldDef] = [
             "Data source URL. For Home Assistant: "
             "http://[HA_HOST]:[PORT]/api/states/[sensor_entity]. "
             "For HTTP servers: endpoint URL returning JSON timeseries. "
-            "Must return JSON array with {start, end, value} format."
+            "Must return a JSON array in EVCC's {start, end, value} format; "
+            "'end' is optional. The unit of 'value' is set by "
+            "pv_forecast_source.value_unit."
         ),
         help_url="configuration.html#pv-forecast-sources",
         depends_on={
@@ -1271,6 +1292,24 @@ _ALL_FIELDS: list[FieldDef] = [
             "pv_forecast_source.source": ["timeseries"],
             "pv_forecast_source.use_ha_central_data_source": [False],
         },
+        hot_reload=True,
+        display_group="Provider",
+    ),
+    FieldDef(
+        key="pv_forecast_source.value_unit",
+        field_type="select",
+        default="W",
+        section="pv_forecast_source",
+        level="getting_started",
+        description=(
+            "Unit of the 'value' field in the timeseries. Default matches EVCC's "
+            "solar forecast and the usual Home Assistant PV sensors, which report "
+            "power (W) per slot. Pick Wh/kWh for a source that reports energy per "
+            "slot instead."
+        ),
+        help_url="configuration.html#pv-forecast-sources",
+        validation={"choices": ["W", "kW", "Wh", "kWh"]},
+        depends_on={"pv_forecast_source.source": ["timeseries"]},
         hot_reload=True,
         display_group="Provider",
     ),

--- a/src/config_web/timeseries_probe.py
+++ b/src/config_web/timeseries_probe.py
@@ -1,0 +1,338 @@
+"""
+Pre-flight probe for the unified ``timeseries`` data source.
+
+The timeseries source deliberately accepts exactly one format (see
+``interfaces/timeseries_normalizer``). Strictness is only workable if the user can see
+*why* a source was rejected — and, just as important, see the numbers a source that was
+*accepted* actually produces. A payload can match the format perfectly and still be
+wrong by a factor of 1000 if the unit is misconfigured; the only way to catch that is to
+show the converted value in the unit the user reads elsewhere in the UI.
+
+This module therefore performs the same fetch → extract → normalize → convert chain the
+running interfaces perform, and reports the outcome. It reuses the interfaces' own
+normalizer and path extractor so that "the test passed" means the interface will
+succeed too.
+"""
+
+import logging
+
+import pytz
+import requests
+
+try:  # running from src/ as a script — src/ is on sys.path
+    from interfaces.timeseries_normalizer import (
+        PRICE_UNIT_TO_EUR_PER_WH,
+        PV_UNITS,
+        TEMPLATE_DOCS_ANCHOR,
+        TimeseriesFormatError,
+        convert_price_values,
+        convert_pv_values,
+        detect_resolution_seconds,
+        extract_json_path,
+        normalize_entries,
+        price_plausibility_message,
+        pv_plausibility_message,
+    )
+except ImportError:  # imported as src.config_web (tests)
+    from ..interfaces.timeseries_normalizer import (
+        PRICE_UNIT_TO_EUR_PER_WH,
+        PV_UNITS,
+        TEMPLATE_DOCS_ANCHOR,
+        TimeseriesFormatError,
+        convert_price_values,
+        convert_pv_values,
+        detect_resolution_seconds,
+        extract_json_path,
+        normalize_entries,
+        price_plausibility_message,
+        pv_plausibility_message,
+    )
+
+logger = logging.getLogger("__main__")
+
+REQUEST_TIMEOUT_SECONDS = 10
+
+# How many normalized slots to hand back for display.
+SAMPLE_SLOT_COUNT = 3
+
+
+def _display(domain, value):
+    """Render one converted value in the unit the rest of the UI shows."""
+    if domain == "price":
+        # Internal unit is EUR/Wh; the schedule table shows ct/kWh.
+        return {"value": round(value * 100_000, 2), "unit": "ct/kWh"}
+    return {"value": round(value, 1), "unit": "Wh"}
+
+
+def _status_error(status, url_field, resource_label):
+    """Map an HTTP status onto a curated, actionable message (or None if it is fine)."""
+    if status in (401, 403):
+        return {
+            "ok": False,
+            "field": url_field,
+            "error": (
+                f"Endpoint refused the request ({status}). Check the access token."
+            ),
+        }
+    if status == 404:
+        return {
+            "ok": False,
+            "field": url_field,
+            "error": f"'{resource_label}' not found (404). Check the URL / sensor entity name.",
+        }
+    if status >= 400:
+        return {
+            "ok": False,
+            "field": url_field,
+            "error": f"Endpoint returned HTTP {status}.",
+        }
+    return None
+
+
+def probe(
+    domain,
+    data_url,
+    data_path,
+    data_token,
+    value_unit,
+    time_zone,
+    resource_label=None,
+    time_frame_base=3600,
+    installed_power_w=0,
+):
+    """
+    Fetch and validate a timeseries endpoint without touching any running interface.
+
+    Args:
+        domain: "price" or "pv" — selects the unit table and the display unit.
+        data_url: Endpoint to fetch.
+        data_path: Dot-notation path to the timeseries array.
+        data_token: Optional bearer token.
+        value_unit: Configured unit of the "value" field.
+        time_zone: Zone name or tzinfo used to resolve timestamps.
+        resource_label: What to call the thing being fetched in messages — the HA
+            sensor entity when the URL was derived from one, else the URL itself.
+        time_frame_base: The system's slot length (900 or 3600). Reported as a failure
+            when the source cannot satisfy it, because the interfaces reject that
+            combination outright and would otherwise fall back silently.
+        installed_power_w: Total configured array power, used only to sanity-check PV
+            magnitudes. Zero disables that check.
+
+    Returns:
+        dict: ``{"ok": bool, ...}``. On success: entry_count, resolution_seconds,
+        value_unit, slots (start/end/value/unit) and warnings. On failure: a curated
+        ``error`` string safe to show the user, plus ``field`` naming the config key
+        most likely at fault.
+
+    Never raises: every failure path is reported as a result so the caller can render
+    it next to the field.
+    """
+    if domain not in ("price", "pv"):
+        return {"ok": False, "error": f"unknown probe domain '{domain}'"}
+
+    units = PRICE_UNIT_TO_EUR_PER_WH if domain == "price" else PV_UNITS
+    unit_field = "price.value_unit" if domain == "price" else "pv_forecast_source.value_unit"
+    url_field = "price.data_url" if domain == "price" else "pv_forecast_source.data_url"
+    path_field = "price.data_path" if domain == "price" else "pv_forecast_source.data_path"
+
+    if not data_url:
+        return {
+            "ok": False,
+            "field": url_field,
+            "error": "No data URL configured.",
+            "transport": True,
+        }
+
+    if value_unit not in units:
+        return {
+            "ok": False,
+            "field": unit_field,
+            "error": (
+                f"Unknown unit '{value_unit}'. Expected one of: "
+                f"{', '.join(sorted(units))}."
+            ),
+        }
+
+    try:
+        tz = pytz.timezone(time_zone) if isinstance(time_zone, str) else time_zone
+    except pytz.UnknownTimeZoneError:
+        tz = pytz.UTC
+
+    headers = {"Content-Type": "application/json"}
+    if data_token:
+        headers["Authorization"] = f"Bearer {data_token}"
+
+    label = resource_label or data_url
+
+    try:
+        response = requests.get(
+            data_url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
+        )
+    except requests.exceptions.Timeout:
+        logger.warning("[Probe] Timeseries probe timed out for %s", data_url)
+        return {
+            "ok": False,
+            "field": url_field,
+            "error": f"No response within {REQUEST_TIMEOUT_SECONDS}s. Check the URL and network.",
+            "transport": True,
+        }
+    except requests.exceptions.RequestException as exc:
+        # An HTTPError may carry the response that caused it (raise_for_status, or a
+        # hook raising early). Report that status rather than a generic failure.
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status is not None:
+            status_error = _status_error(status, url_field, label)
+            if status_error:
+                return status_error
+        # Curated message only — the exception text can carry internal detail.
+        logger.warning("[Probe] Timeseries probe request failed: %s", exc, exc_info=True)
+        return {
+            "ok": False,
+            "field": url_field,
+            "error": "Could not reach the endpoint. Check the URL, port and TLS settings.",
+            "transport": True,
+        }
+
+    status_error = _status_error(response.status_code, url_field, label)
+    if status_error:
+        return status_error
+
+    try:
+        payload = response.json()
+    except ValueError:
+        return {
+            "ok": False,
+            "field": url_field,
+            "error": "Response is not valid JSON.",
+        }
+
+    raw_entries = extract_json_path(payload, data_path, label="Probe")
+    if raw_entries is None:
+        available = (
+            ", ".join(repr(k) for k in payload.keys())
+            if isinstance(payload, dict)
+            else f"response is a {type(payload).__name__}"
+        )
+        return {
+            "ok": False,
+            "field": path_field,
+            "error": (
+                f"Path '{data_path}' does not exist in the response "
+                f"(top level: {available})."
+            ),
+        }
+
+    try:
+        entries = normalize_entries(raw_entries, tz, label="Probe")
+    except TimeseriesFormatError as exc:
+        return {"ok": False, "field": path_field, "error": str(exc)}
+
+    warnings = []
+    resolution_seconds = detect_resolution_seconds(entries)
+    if resolution_seconds is None:
+        if len(entries) < 2:
+            return {
+                "ok": False,
+                "field": path_field,
+                "error": (
+                    "Only one entry found — at least two are needed to determine the "
+                    "slot resolution."
+                ),
+            }
+        delta = int((entries[1]["start"] - entries[0]["start"]).total_seconds())
+        return {
+            "ok": False,
+            "field": path_field,
+            "error": (
+                f"Unsupported slot resolution: {delta}s between the first two entries. "
+                "Only 900s (15 min) and 3600s (hourly) are supported."
+            ),
+        }
+
+    if resolution_seconds == 3600 and time_frame_base == 900:
+        # PriceInterface / PvInterface refuse this combination and fall back, so a
+        # green test here would be a lie.
+        return {
+            "ok": False,
+            "field": path_field,
+            "error": (
+                "Source provides hourly data, but the system is configured for "
+                "15-minute slots (eos.time_frame = 900). Use a 15-minute source or "
+                "set the time frame to 3600."
+            ),
+        }
+
+    try:
+        if domain == "price":
+            convert_price_values(entries, value_unit)
+        else:
+            convert_pv_values(entries, value_unit, resolution_seconds)
+    except TimeseriesFormatError as exc:
+        return {"ok": False, "field": unit_field, "error": str(exc)}
+
+    if domain == "price":
+        plausibility = price_plausibility_message(
+            [entry["value"] for entry in entries], value_unit
+        )
+    else:
+        plausibility = pv_plausibility_message(
+            [entry["value"] for entry in entries],
+            value_unit,
+            resolution_seconds,
+            installed_power_w,
+        )
+    if plausibility:
+        warnings.append(plausibility)
+
+    naive_hint = (
+        f"Timestamps carry no UTC offset and were read as local time "
+        f"({getattr(tz, 'zone', str(tz))}). If the source renders UTC, every slot is "
+        f"shifted — see {TEMPLATE_DOCS_ANCHOR}."
+    )
+    if _has_naive_source_timestamps(raw_entries):
+        warnings.append(naive_hint)
+
+    slots = []
+    for entry in entries[:SAMPLE_SLOT_COUNT]:
+        rendered = _display(domain, entry["value"])
+        slots.append(
+            {
+                "start": entry["start"].isoformat(),
+                "end": entry["end"].isoformat() if entry["end"] else None,
+                "value": rendered["value"],
+                "unit": rendered["unit"],
+            }
+        )
+
+    return {
+        "ok": True,
+        "entry_count": len(entries),
+        "resolution_seconds": resolution_seconds,
+        "value_unit": value_unit,
+        "slots": slots,
+        "warnings": warnings,
+    }
+
+
+def _has_naive_source_timestamps(raw_entries):
+    """
+    True when the source's own ``start`` strings omit a UTC offset.
+
+    Checked against the raw payload rather than the normalized entries, because
+    normalization has already localized them by then.
+    """
+    if not isinstance(raw_entries, list):
+        return False
+    for raw in raw_entries[:1]:
+        if not isinstance(raw, dict):
+            continue
+        start = raw.get("start")
+        if not isinstance(start, str):
+            continue
+        text = start.strip()
+        if text.endswith("Z"):
+            return False
+        # An offset appears as +HH:MM / -HH:MM at the tail, after the date part.
+        tail = text[10:]
+        return "+" not in tail and "-" not in tail
+    return False

--- a/src/interfaces/price_interface.py
+++ b/src/interfaces/price_interface.py
@@ -41,6 +41,14 @@ import threading
 import time
 import requests
 
+from .timeseries_normalizer import (
+    TimeseriesFormatError,
+    convert_price_values,
+    extract_json_path,
+    normalize_entries,
+    price_plausibility_message,
+)
+
 logger = logging.getLogger("__main__")
 logger.info("[PRICE-IF] loading module ")
 
@@ -144,6 +152,9 @@ class PriceInterface:
         self.data_url = config.get("data_url", "").strip()
         self.data_path = config.get("data_path", "attributes.data").strip()
         self.data_token = config.get("data_token", "").strip()
+        # Unit of the source's "value" field. Default matches EVCC's `rates`, which is
+        # the reference format for this source — see timeseries_normalizer.
+        self.value_unit = config.get("value_unit", "EUR/kWh").strip()
 
         # EVCC interface for EVCC price source
         self.evcc_interface = evcc_interface
@@ -1760,15 +1771,17 @@ class PriceInterface:
         """
         Retrieve grid prices from timeseries data source (Home Assistant or HTTP).
 
-        Unified approach for both HA sensors and custom HTTP servers using
-        standardized timeseries format: [{start, end, value}, ...] with values
-        in EUR/Wh.
+        Unified approach for both HA sensors and custom HTTP servers using the
+        canonical timeseries format: [{start, end, value}, ...] — the format EVCC
+        publishes, so an EVCC endpoint or an EVCC-shaped HA template sensor works
+        unchanged. See timeseries_normalizer for the exact contract.
 
         Config fields used:
         - data_url: Full HTTP endpoint URL (HA or HTTP custom endpoint)
         - data_path: JSON path to timeseries array (e.g., 'attributes.data')
         - data_token: Optional bearer token for authentication
-        
+        - value_unit: Unit of the "value" field (default EUR/kWh, as EVCC delivers)
+
         Args:
             tgt_duration (int): Target duration in hours (48) or 15-min slots (192)
             start_time (datetime, optional): Optional start time
@@ -1788,9 +1801,10 @@ class PriceInterface:
             headers["Authorization"] = f"Bearer {self.data_token}"
 
         logger.debug(
-            "[PRICE-IF] Fetching prices from timeseries source: %s (path: %s)",
+            "[PRICE-IF] Fetching prices from timeseries source: %s (path: %s, unit: %s)",
             self.data_url,
             self.data_path,
+            self.value_unit,
         )
 
         def request_and_parse():
@@ -1800,7 +1814,9 @@ class PriceInterface:
             response_data = response.json()
 
             # Extract timeseries using data_path
-            timeseries = self.__extract_json_path(response_data, self.data_path)
+            timeseries = extract_json_path(
+                response_data, self.data_path, label="PRICE-IF"
+            )
 
             if not isinstance(timeseries, list):
                 msg = f"Data at path '{self.data_path}' is not array"
@@ -1819,7 +1835,13 @@ class PriceInterface:
 
         # Parse and validate timeseries
         try:
-            prices = self.__parse_price_timeseries(timeseries, tgt_duration, None, start_time)
+            prices = self.__parse_price_timeseries(
+                timeseries,
+                tgt_duration,
+                None,
+                start_time,
+                value_unit=self.value_unit,
+            )
             if not prices:
                 logger.error("[PRICE-IF] Failed to parse price timeseries data")
                 return []
@@ -1828,6 +1850,19 @@ class PriceInterface:
             self.consecutive_failures = 0
             self.last_successful_prices = prices.copy()
             self.last_successful_prices_direct = prices.copy()
+
+            # State the unit once per unit change. The canonical unit moved from
+            # EUR/Wh to EUR/kWh, so a config carried over from an earlier version
+            # silently changes meaning — this makes the active interpretation visible
+            # in the log without spamming it every cycle.
+            if getattr(self, "_logged_value_unit", None) != self.value_unit:
+                logger.info(
+                    "[PRICE-IF] Timeseries prices interpreted as '%s' "
+                    "(first slot: %.2f ct/kWh)",
+                    self.value_unit,
+                    prices[0] * 100_000,
+                )
+                self._logged_value_unit = self.value_unit
 
             logger.debug(
                 "[PRICE-IF] Timeseries prices received: %d values, "
@@ -2105,20 +2140,32 @@ class PriceInterface:
             logger.error(f"[PRICE-IF] Unexpected error fetching EVCC prices: {e}")
             return []
 
-    def __parse_price_timeseries(self, timeseries, tgt_duration, resolution_seconds=None, start_time=None):
+    def __parse_price_timeseries(
+        self,
+        timeseries,
+        tgt_duration,
+        resolution_seconds=None,
+        start_time=None,
+        value_unit=None,
+    ):
         """
         Parse and validate price timeseries format.
 
         Standardized format: [{start, end, value}, ...]
-        - start/end: ISO8601 string or Unix timestamp (seconds)
-        - value: numeric in EUR/Wh
+        - start: ISO8601 string or Unix timestamp (seconds)
+        - end: optional, derived from the next entry when absent
+        - value: numeric, in *value_unit*
         - Supports hourly (48 values) or 15-minute (192 values) resolution
 
         Args:
-            timeseries: List of price entries with start, end, value
+            timeseries: List of price entries with start and value
             tgt_duration: Target duration in hours
             resolution_seconds: Pre-detected resolution (900 or 3600), or None to auto-detect
             start_time: Window start time (datetime) for timestamp-aware conversion
+            value_unit: Unit of the incoming values (see
+                timeseries_normalizer.PRICE_UNIT_TO_EUR_PER_WH). ``None`` means the
+                caller already supplies canonical EUR/Wh values and needs no
+                normalization — that is how the EVCC path feeds this method.
 
         Returns:
             list: Normalized hourly price values in EUR/Wh, or empty on error
@@ -2131,14 +2178,33 @@ class PriceInterface:
             logger.error("[PRICE-IF] Price timeseries is empty")
             return []
 
-        # Validate first entry structure
-        first = timeseries[0]
-        required_keys = ["start", "end", "value"]
-        if not isinstance(first, dict) or not all(k in first for k in required_keys):
-            logger.error(
-                "[PRICE-IF] Invalid price timeseries format: missing start, end, or value"
+        if value_unit is not None:
+            # External source: normalize field/timestamp shape and convert the unit
+            # before any of the resolution logic below looks at the entries.
+            try:
+                timeseries = normalize_entries(
+                    timeseries, self.time_zone, label="PRICE-IF"
+                )
+                convert_price_values(timeseries, value_unit)
+            except TimeseriesFormatError as exc:
+                logger.error("[PRICE-IF] Invalid price timeseries: %s", exc)
+                return []
+
+            warning = price_plausibility_message(
+                [entry["value"] for entry in timeseries], value_unit
             )
-            return []
+            if warning:
+                logger.warning("[PRICE-IF] %s", warning)
+        else:
+            # Validate first entry structure for pre-normalized input
+            first = timeseries[0]
+            if not isinstance(first, dict) or not all(
+                k in first for k in ("start", "value")
+            ):
+                logger.error(
+                    "[PRICE-IF] Invalid price timeseries format: missing start or value"
+                )
+                return []
 
         # Detect time resolution from timestamp delta (unless already provided)
         if resolution_seconds is None:
@@ -2222,7 +2288,10 @@ class PriceInterface:
             import pytz
 
             def parse_ts(ts_str):
-                """Parse timestamp from ISO8601 or Unix seconds."""
+                """Parse timestamp from a datetime, ISO8601 string or Unix seconds."""
+                if isinstance(ts_str, dt_class):
+                    # Already normalized by timeseries_normalizer.
+                    return ts_str
                 if isinstance(ts_str, (int, float)):
                     return dt_class.fromtimestamp(ts_str, tz=pytz.UTC)
                 if isinstance(ts_str, str):
@@ -2282,7 +2351,10 @@ class PriceInterface:
             if start_time is None:
                 # Parse first timestamp as reference
                 first_ts = timeseries[0].get("start")
-                if isinstance(first_ts, str):
+                if isinstance(first_ts, dt_class):
+                    # Already normalized by timeseries_normalizer.
+                    window_start = first_ts
+                elif isinstance(first_ts, str):
                     try:
                         window_start = dt_class.fromisoformat(first_ts.replace('Z', '+00:00'))
                     except (ValueError, AttributeError):
@@ -2305,7 +2377,10 @@ class PriceInterface:
                 try:
                     # Parse entry timestamp
                     ts_str = entry.get("start")
-                    if isinstance(ts_str, str):
+                    if isinstance(ts_str, dt_class):
+                        # Already normalized by timeseries_normalizer.
+                        entry_time = ts_str
+                    elif isinstance(ts_str, str):
                         entry_time = dt_class.fromisoformat(ts_str.replace('Z', '+00:00'))
                     else:
                         from datetime import timezone
@@ -2425,38 +2500,3 @@ class PriceInterface:
             except (ValueError, TypeError):
                 pass
         return hourly
-
-    def __extract_json_path(self, obj, path):
-        """
-        Extract nested value from JSON object using dot notation.
-
-        Examples:
-        - 'attributes.data' -> obj['attributes']['data']
-        - 'data' -> obj['data']
-        - 'prices[0].data' -> obj['prices'][0]['data']
-
-        Args:
-            obj: JSON object (dict or list)
-            path: Dot-notation path string
-
-        Returns:
-            Extracted value or None if path not found
-        """
-        try:
-            parts = path.split(".")
-            current = obj
-            for part in parts:
-                if "[" in part:
-                    # Handle array index notation (e.g., "prices[0]")
-                    key, index_str = part.split("[")
-                    index = int(index_str.rstrip("]"))
-                    if key:
-                        current = current[key][index]
-                    else:
-                        current = current[index]
-                else:
-                    current = current[part]
-            return current
-        except (KeyError, IndexError, TypeError, ValueError):
-            logger.warning("[PRICE-IF] Could not extract path '%s' from JSON response", path)
-            return None

--- a/src/interfaces/pv_interface.py
+++ b/src/interfaces/pv_interface.py
@@ -36,6 +36,15 @@ import pandas as pd
 import numpy as np
 from open_meteo_solar_forecast import OpenMeteoSolarForecast
 
+from .timeseries_normalizer import (
+    TEMPLATE_DOCS_ANCHOR,
+    TimeseriesFormatError,
+    convert_pv_values,
+    extract_json_path,
+    normalize_entries,
+    pv_plausibility_message,
+)
+
 logger = logging.getLogger("__main__")
 logger.info("[PV-IF] loading module ")
 
@@ -1105,17 +1114,23 @@ class PvInterface:
         external source is expected to already provide the combined forecast
         for the whole installation - mirrors how the "evcc" source is handled.
 
-        Standardized format: [{start, end, value}, ...] with value in Wh for
-        that slot (hourly or 15-min resolution, auto-detected).
+        Canonical format: [{start, end, value}, ...] — the format EVCC publishes, so
+        an EVCC-shaped HA template sensor works unchanged. See timeseries_normalizer
+        for the exact contract. Resolution (hourly or 15-min) is auto-detected.
 
         Config fields used (from pv_forecast_source):
         - data_url: Full HTTP endpoint URL (HA or HTTP custom endpoint)
-        - data_path: JSON path to the timeseries array (e.g. "data")
+        - data_path: JSON path to the timeseries array (e.g. "attributes.data")
         - data_token: Optional bearer token for authentication
+        - value_unit: Unit of the "value" field (default W, as EVCC delivers)
         """
         data_url = self.config_source.get("data_url", "").strip()
-        data_path = self.config_source.get("data_path", "data").strip() or "data"
+        data_path = (
+            self.config_source.get("data_path", "attributes.data").strip()
+            or "attributes.data"
+        )
         data_token = self.config_source.get("data_token", "").strip()
+        value_unit = self.config_source.get("value_unit", "W").strip() or "W"
 
         fallback_power = self.config[0]["power"] if self.config else 1000
 
@@ -1132,16 +1147,17 @@ class PvInterface:
             headers["Authorization"] = f"Bearer {data_token}"
 
         logger.debug(
-            "[PV-IF] Fetching PV forecast from timeseries source: %s (path: %s)",
+            "[PV-IF] Fetching PV forecast from timeseries source: %s (path: %s, unit: %s)",
             data_url,
             data_path,
+            value_unit,
         )
 
         def request_and_parse():
             response = requests.get(data_url, headers=headers, timeout=10)
             response.raise_for_status()
             response_data = response.json()
-            timeseries = self.__extract_json_path(response_data, data_path)
+            timeseries = extract_json_path(response_data, data_path, label="PV-IF")
             if not isinstance(timeseries, list):
                 raise ValueError(f"Data at path '{data_path}' is not a list")
             return timeseries
@@ -1198,7 +1214,9 @@ class PvInterface:
                 "[PV-IF] Timeseries fetched successfully (%d entries) - parsing...",
                 len(timeseries),
             )
-            forecast_values = self.__parse_pv_timeseries(timeseries, tgt_duration)
+            forecast_values = self.__parse_pv_timeseries(
+                timeseries, tgt_duration, value_unit=value_unit
+            )
             if not forecast_values:
                 logger.warning(
                     "[PV-IF] Timeseries parsing returned empty - "
@@ -1231,19 +1249,27 @@ class PvInterface:
                 "timeseries",
             ) or self.__get_default_pv_forcast(fallback_power)
 
-    def __parse_pv_timeseries(self, timeseries, tgt_duration, resolution_seconds=None):
+    def __parse_pv_timeseries(
+        self, timeseries, tgt_duration, resolution_seconds=None, value_unit=None
+    ):
         """
         Parse and validate a PV forecast timeseries.
 
-        Standardized format: [{start, end, value}, ...]
-        - start/end: ISO8601 string or Unix timestamp (seconds)
-        - value: generated energy in Wh for that slot (non-negative)
+        Canonical format: [{start, end, value}, ...]
+        - start: ISO8601 string or Unix timestamp (seconds)
+        - end: optional, derived from the next entry when absent
+        - value: generated power/energy in *value_unit* (non-negative)
         - Supports hourly (48 values) or 15-minute (192 values) resolution
 
         Mirrors PriceInterface.__parse_price_timeseries, adapted for PV: values
         represent energy-per-slot rather than a rate, so 15-min-to-hourly
         conversion sums instead of averages, and missing trailing slots are
         padded with 0 (no production) rather than the last known value.
+
+        Args:
+            value_unit: Unit of the incoming values (see
+                timeseries_normalizer.PV_UNITS). ``None`` means the caller already
+                supplies canonical Wh-per-slot values and needs no normalization.
         """
         if not timeseries or not isinstance(timeseries, list):
             logger.error("[PV-IF] PV timeseries is not a list")
@@ -1253,13 +1279,70 @@ class PvInterface:
             logger.error("[PV-IF] PV timeseries is empty")
             return []
 
-        first = timeseries[0]
-        required_keys = ["start", "end", "value"]
-        if not isinstance(first, dict) or not all(k in first for k in required_keys):
-            logger.error(
-                "[PV-IF] Invalid PV timeseries format: missing start, end, or value"
+        # self.time_zone is a zone *name* here, not a tzinfo — resolve it once for both
+        # normalization and the slot alignment further down.
+        try:
+            tz = pytz.timezone(self.time_zone)
+        except (pytz.UnknownTimeZoneError, AttributeError):
+            tz = pytz.UTC
+
+        if value_unit is not None:
+            # External source: normalize field/timestamp shape first, then detect the
+            # source resolution, because a power unit only becomes energy once the
+            # slot length is known.
+            try:
+                timeseries = normalize_entries(timeseries, tz, label="PV-IF")
+            except TimeseriesFormatError as exc:
+                logger.error("[PV-IF] Invalid PV timeseries: %s", exc)
+                return []
+
+            if resolution_seconds is None:
+                resolution_seconds = self.__detect_pv_timeseries_resolution(timeseries)
+                if resolution_seconds is None:
+                    logger.error("[PV-IF] Could not detect PV timeseries resolution")
+                    return []
+
+            try:
+                convert_pv_values(timeseries, value_unit, resolution_seconds)
+            except TimeseriesFormatError as exc:
+                logger.error("[PV-IF] Invalid PV timeseries: %s", exc)
+                return []
+
+            installed_power_w = sum(
+                float(entry.get("power", 0) or 0)
+                for entry in (self.config or [])
+                if isinstance(entry, dict)
             )
-            return []
+            warning = pv_plausibility_message(
+                [entry["value"] for entry in timeseries],
+                value_unit,
+                resolution_seconds,
+                installed_power_w,
+            )
+            if warning:
+                logger.warning("[PV-IF] %s", warning)
+
+            # State the unit once per unit change. The canonical unit moved from
+            # Wh-per-slot to W, so a config carried over from an earlier version
+            # silently changes meaning on 15-minute data.
+            if getattr(self, "_logged_value_unit", None) != value_unit:
+                logger.info(
+                    "[PV-IF] Timeseries PV values interpreted as '%s' at %ds "
+                    "resolution (peak %.0f Wh per slot)",
+                    value_unit,
+                    resolution_seconds,
+                    max((entry["value"] for entry in timeseries), default=0.0),
+                )
+                self._logged_value_unit = value_unit
+        else:
+            first = timeseries[0]
+            if not isinstance(first, dict) or not all(
+                k in first for k in ("start", "value")
+            ):
+                logger.error(
+                    "[PV-IF] Invalid PV timeseries format: missing start or value"
+                )
+                return []
 
         if resolution_seconds is None:
             resolution_seconds = self.__detect_pv_timeseries_resolution(timeseries)
@@ -1291,13 +1374,12 @@ class PvInterface:
         # "slots since midnight" (see eos_connect.py's current_slot calculation),
         # the same convention __get_pv_forecast_evcc_api() already follows. A
         # source whose first entry is "now" (like ours) rather than "midnight"
-        # would otherwise land at the wrong array index.
-        try:
-            tz = pytz.timezone(self.time_zone)
-        except (pytz.UnknownTimeZoneError, AttributeError):
-            tz = pytz.UTC
+        # would otherwise land at the wrong array index. (tz resolved above.)
 
         def parse_ts(ts_val):
+            if isinstance(ts_val, datetime):
+                # Already normalized (and localized) by timeseries_normalizer.
+                return ts_val.astimezone(tz)
             if isinstance(ts_val, (int, float)):
                 return datetime.fromtimestamp(ts_val, tz=pytz.UTC).astimezone(tz)
             if isinstance(ts_val, str):
@@ -1337,10 +1419,34 @@ class PvInterface:
         now_local = datetime.now(tz)
         midnight_today = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
         expected_count = 48 if self.time_frame_base == 3600 else 192
-        values = [
-            round(lookup.get(midnight_today + timedelta(seconds=slot_seconds * i), 0.0), 1)
+        slot_keys = [
+            midnight_today + timedelta(seconds=slot_seconds * i)
             for i in range(expected_count)
         ]
+        values = [round(lookup.get(key, 0.0), 1) for key in slot_keys]
+
+        matched = sum(1 for key in slot_keys if key in lookup)
+        if matched == 0 and lookup:
+            # Every entry parsed but none landed in the window. Returning 48 zeros
+            # here reads as "no sun for two days" and used to pass silently; the most
+            # common cause is a timestamp without UTC offset, so name what we saw.
+            first_source_ts = min(lookup)
+            logger.warning(
+                "[PV-IF] None of %d PV timeseries entries fell into the %d-slot "
+                "window starting %s. First source timestamp is %s — if the source "
+                "renders UTC without an offset, every slot is shifted. See %s",
+                len(lookup),
+                expected_count,
+                midnight_today.isoformat(),
+                first_source_ts.isoformat(),
+                TEMPLATE_DOCS_ANCHOR,
+            )
+        elif matched < expected_count:
+            logger.debug(
+                "[PV-IF] PV timeseries filled %d of %d slots (rest padded with 0)",
+                matched,
+                expected_count,
+            )
 
         return values
 
@@ -1360,6 +1466,9 @@ class PvInterface:
             import pytz
 
             def parse_ts(ts_str):
+                if isinstance(ts_str, dt_class):
+                    # Already normalized by timeseries_normalizer.
+                    return ts_str
                 if isinstance(ts_str, (int, float)):
                     return dt_class.fromtimestamp(ts_str, tz=pytz.UTC)
                 if isinstance(ts_str, str):
@@ -1426,42 +1535,6 @@ class PvInterface:
             len(hourly),
         )
         return hourly
-
-    def __extract_json_path(self, obj, path):
-        """
-        Extract nested value from JSON object using dot notation.
-
-        Examples:
-        - 'attributes.data' -> obj['attributes']['data']
-        - 'data' -> obj['data']
-        - 'prices[0].data' -> obj['prices'][0]['data']
-
-        Args:
-            obj: JSON object (dict or list)
-            path: Dot-notation path string
-
-        Returns:
-            Extracted value or None if path not found
-        """
-        try:
-            parts = path.split(".")
-            current = obj
-            for part in parts:
-                if "[" in part:
-                    key, index_str = part.split("[")
-                    index = int(index_str.rstrip("]"))
-                    if key:
-                        current = current[key][index]
-                    else:
-                        current = current[index]
-                else:
-                    current = current[part]
-            return current
-        except (KeyError, IndexError, TypeError, ValueError):
-            logger.warning(
-                "[PV-IF] Could not extract path '%s' from JSON response", path
-            )
-            return None
 
     def __get_pv_forecast_akkudoktor_api(
         self, tgt_value="power", pv_config_entry=None, tgt_duration=48

--- a/src/interfaces/timeseries_normalizer.py
+++ b/src/interfaces/timeseries_normalizer.py
@@ -1,0 +1,418 @@
+# -*- coding: utf-8 -*-
+"""
+Normalization of external timeseries payloads into the canonical EOS Connect format.
+
+The canonical format is the one EVCC publishes, because that is the format users
+already have on hand — either straight from an EVCC endpoint, or from a Home Assistant
+template sensor written to feed EVCC (see discussion #214):
+
+    {"start": "2026-08-23T00:00:00+02:00",
+     "end":   "2026-08-23T00:15:00+02:00",
+     "value": 0.3811}
+
+    - start: ISO8601 (offset strongly recommended) or Unix seconds
+    - end:   optional; derived from the next entry's start when absent
+    - value: prices in EUR/kWh (EVCC `rates`), PV in W (EVCC `forecast.solar`)
+
+Home Assistant is the transport here, not the format: whatever a given integration
+names its attributes, the user shapes it into the above with a template sensor. This
+module therefore does not guess field names — it validates them and, on mismatch,
+reports which keys the payload actually had so the user can write that template.
+
+The unit conversions live here as plain tables so the price and PV interfaces share one
+definition instead of each carrying its own factor-of-1000.
+"""
+
+from datetime import datetime, timedelta
+import logging
+
+import pytz
+
+logger = logging.getLogger("__main__")
+
+# Anchor in docs/user-guide/configuration.html holding the ready-made HA template
+# snippets. Referenced from error messages, so a format mismatch points at the fix.
+TEMPLATE_DOCS_ANCHOR = "configuration.html#timeseries-templates"
+
+# Price units → EUR/Wh, the unit the optimizer and the web UI work in internally.
+PRICE_UNIT_TO_EUR_PER_WH = {
+    "EUR/kWh": 1e-3,
+    "ct/kWh": 1e-5,
+    "EUR/Wh": 1.0,
+}
+
+# PV units → Wh per slot. Power units additionally need the slot length, so each entry
+# carries whether it is a power reading.
+PV_UNITS = {
+    "W": {"factor": 1.0, "is_power": True},
+    "kW": {"factor": 1000.0, "is_power": True},
+    "Wh": {"factor": 1.0, "is_power": False},
+    "kWh": {"factor": 1000.0, "is_power": False},
+}
+
+# Plausibility band for grid prices, in ct/kWh. Wide enough to pass any real tariff
+# (including negative spot hours, which are filtered out by taking the median) and
+# narrow enough that a factor-1000 unit error falls outside it in either direction.
+PRICE_PLAUSIBLE_MIN_CT_KWH = 0.5
+PRICE_PLAUSIBLE_MAX_CT_KWH = 150.0
+
+# How far a PV peak may exceed installed capacity before it is called implausible.
+# Headroom covers optimistic forecasts and arrays oversized against their inverter;
+# the unit mistake it has to catch is a factor of four.
+PV_PEAK_TOLERANCE = 1.5
+
+
+class TimeseriesFormatError(ValueError):
+    """
+    Raised when a payload does not match the canonical format.
+
+    The message is written to be shown to the user: it names the missing field, the
+    keys that were actually present, and where to find a template snippet. Callers may
+    surface it verbatim — it carries no exception text from lower layers.
+    """
+
+
+def _parse_timestamp(raw, tz):
+    """
+    Parse one timestamp into a timezone-aware datetime in *tz*.
+
+    Returns (datetime, was_naive). A naive input is localized to *tz* rather than
+    rejected, but the flag lets the caller warn once: a HA template using
+    ``| timestamp_utc`` emits UTC wall-clock without an offset, which would otherwise
+    be silently read as local time and shift every slot.
+    """
+    if isinstance(raw, bool):
+        # bool is an int subclass; treating True as epoch 1 would be nonsense.
+        raise TimeseriesFormatError(
+            f"'start' must be a timestamp, got boolean {raw!r}"
+        )
+
+    if isinstance(raw, (int, float)):
+        return datetime.fromtimestamp(raw, tz=pytz.UTC).astimezone(tz), False
+
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            raise TimeseriesFormatError("'start' is an empty string")
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise TimeseriesFormatError(
+                f"'start' value {raw!r} is not a valid ISO8601 timestamp "
+                f"or Unix timestamp"
+            ) from exc
+        if parsed.tzinfo is None:
+            # localize() is pytz-specific; fall back for plain tzinfo objects.
+            if hasattr(tz, "localize"):
+                parsed = tz.localize(parsed)
+            else:
+                parsed = parsed.replace(tzinfo=tz)
+            return parsed, True
+        return parsed.astimezone(tz), False
+
+    raise TimeseriesFormatError(
+        f"'start' must be an ISO8601 string or Unix timestamp, got {type(raw).__name__}"
+    )
+
+
+def _describe_available_keys(entry):
+    """Render the keys an entry actually carries, for an actionable error message."""
+    if not isinstance(entry, dict):
+        return f"entry is {type(entry).__name__}, not an object"
+    if not entry:
+        return "entry is an empty object"
+    return "available fields: " + ", ".join(repr(k) for k in entry.keys())
+
+
+def normalize_entries(raw_entries, tz, label="timeseries"):
+    """
+    Validate and normalize a raw payload into the canonical format.
+
+    Args:
+        raw_entries: Decoded JSON list from the configured data_path.
+        tz: Target timezone (pytz timezone or tzinfo) for all timestamps.
+        label: Prefix used in log messages, e.g. "PRICE-IF" or "PV-IF".
+
+    Returns:
+        list: ``[{"start": datetime (aware), "end": datetime (aware), "value": float}]``
+        sorted by start, with ``end`` derived where the source omitted it.
+
+    Raises:
+        TimeseriesFormatError: With a user-facing message naming the offending field
+            and the keys that were present instead.
+    """
+    if not isinstance(raw_entries, list):
+        raise TimeseriesFormatError(
+            f"expected a JSON array of timeseries entries, got "
+            f"{type(raw_entries).__name__}"
+        )
+    if not raw_entries:
+        raise TimeseriesFormatError("timeseries is empty")
+
+    first = raw_entries[0]
+    for field in ("start", "value"):
+        if not isinstance(first, dict) or field not in first:
+            raise TimeseriesFormatError(
+                f"missing required field '{field}' in the first entry "
+                f"({_describe_available_keys(first)}). The expected format is "
+                f"{{start, end, value}} — shape the source with a Home Assistant "
+                f"template sensor, see {TEMPLATE_DOCS_ANCHOR}"
+            )
+
+    entries = []
+    naive_seen = 0
+    for index, raw in enumerate(raw_entries):
+        # Every entry has to parse. Dropping the bad ones would be friendlier right
+        # up until it corrupts the result: the hourly price path maps this list to
+        # slots by position, so a single missing entry shifts every later price an
+        # hour early — silently, and in the direction that makes power look cheaper.
+        # Rejecting the payload instead lets the caller fall back to cached data.
+        if not isinstance(raw, dict) or "start" not in raw or "value" not in raw:
+            raise TimeseriesFormatError(
+                f"entry {index} is missing 'start' or 'value' "
+                f"({_describe_available_keys(raw)})"
+            )
+        try:
+            start, was_naive = _parse_timestamp(raw["start"], tz)
+        except TimeseriesFormatError as exc:
+            raise TimeseriesFormatError(f"entry {index}: {exc}") from exc
+        try:
+            value = float(raw["value"])
+        except (TypeError, ValueError) as exc:
+            raise TimeseriesFormatError(
+                f"entry {index} has a non-numeric 'value': {raw['value']!r}"
+            ) from exc
+        if was_naive:
+            naive_seen += 1
+        entries.append({"start": start, "end": None, "value": value})
+
+    if naive_seen:
+        logger.warning(
+            "[%s] %d timeseries timestamp(s) carry no UTC offset and were read as "
+            "local time (%s). If the source renders UTC (e.g. a Home Assistant "
+            "template using '| timestamp_utc'), every slot is shifted — emit ISO8601 "
+            "with offset instead, e.g. '.isoformat()'. See %s",
+            label,
+            naive_seen,
+            getattr(tz, "zone", str(tz)),
+            TEMPLATE_DOCS_ANCHOR,
+        )
+
+    entries.sort(key=lambda item: item["start"])
+    _derive_end_timestamps(entries)
+    return entries
+
+
+def _derive_end_timestamps(entries):
+    """
+    Fill each entry's ``end`` from the following entry's ``start``, in place.
+
+    ``end`` is part of the documented format but is never read for any calculation;
+    deriving it means a source that omits it (Tibber/EPEX HA integrations) is accepted
+    rather than rejected over a field we do not use. The last entry reuses the
+    preceding delta, falling back to one hour for a single-entry series.
+    """
+    count = len(entries)
+    for index in range(count - 1):
+        entries[index]["end"] = entries[index + 1]["start"]
+
+    if count >= 2:
+        last_delta = entries[-1]["start"] - entries[-2]["start"]
+    else:
+        last_delta = timedelta(hours=1)
+    entries[-1]["end"] = entries[-1]["start"] + last_delta
+
+
+def detect_resolution_seconds(entries):
+    """
+    Detect the slot length from the first two normalized entries.
+
+    Returns:
+        int: 900 or 3600, or None when it is neither or cannot be determined.
+    """
+    if len(entries) < 2:
+        return None
+    delta = int((entries[1]["start"] - entries[0]["start"]).total_seconds())
+    if delta in (900, 3600):
+        return delta
+    return None
+
+
+def convert_price_values(entries, unit):
+    """
+    Convert price entries to EUR/Wh in place and return them.
+
+    Args:
+        entries: Normalized entries whose ``value`` is in *unit*.
+        unit: One of PRICE_UNIT_TO_EUR_PER_WH.
+
+    Raises:
+        TimeseriesFormatError: On an unknown unit.
+    """
+    try:
+        factor = PRICE_UNIT_TO_EUR_PER_WH[unit]
+    except KeyError as exc:
+        raise TimeseriesFormatError(
+            f"unknown price unit {unit!r}, expected one of "
+            f"{', '.join(sorted(PRICE_UNIT_TO_EUR_PER_WH))}"
+        ) from exc
+
+    for entry in entries:
+        entry["value"] = entry["value"] * factor
+    return entries
+
+
+def convert_pv_values(entries, unit, resolution_seconds):
+    """
+    Convert PV entries to Wh per slot in place and return them.
+
+    Power units (W, kW) are integrated over the slot length, matching how the EVCC PV
+    adapter treats EVCC's own forecast values. Energy units pass through scaled.
+
+    Args:
+        entries: Normalized entries whose ``value`` is in *unit*.
+        unit: One of PV_UNITS.
+        resolution_seconds: Source slot length in seconds (900 or 3600).
+
+    Raises:
+        TimeseriesFormatError: On an unknown unit.
+    """
+    try:
+        spec = PV_UNITS[unit]
+    except KeyError as exc:
+        raise TimeseriesFormatError(
+            f"unknown PV unit {unit!r}, expected one of {', '.join(sorted(PV_UNITS))}"
+        ) from exc
+
+    factor = spec["factor"]
+    if spec["is_power"]:
+        factor *= resolution_seconds / 3600.0
+
+    for entry in entries:
+        entry["value"] = entry["value"] * factor
+    return entries
+
+
+def _median(values):
+    """Median of a non-empty sequence, without pulling in statistics for one call."""
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2.0
+
+
+def pv_plausibility_message(values_wh, unit, resolution_seconds, installed_power_w):
+    """
+    Check converted PV energies against the installed generator.
+
+    The PV unit mistake (power read as energy, or the reverse) is a factor of four on
+    15-minute data — small enough to look like a bad forecast rather than a
+    misconfiguration. Comparing the peak slot against installed capacity catches it,
+    since no array can exceed its own rating.
+
+    Args:
+        values_wh: Converted energy per slot, in Wh.
+        unit: The configured unit, named in the message.
+        resolution_seconds: Slot length the values belong to.
+        installed_power_w: Sum of the configured array power, or 0 when unknown.
+
+    Returns:
+        str: A user-facing warning, or None when nothing looks wrong. Returns None
+        whenever installed power is unknown — a timeseries source does not require PV
+        installations to be configured, and guessing without a reference would produce
+        noise.
+    """
+    if not values_wh or not installed_power_w or installed_power_w <= 0:
+        return None
+
+    slot_hours = resolution_seconds / 3600.0
+    if slot_hours <= 0:
+        return None
+
+    peak_power_w = max(values_wh) / slot_hours
+    if peak_power_w <= installed_power_w * PV_PEAK_TOLERANCE:
+        return None
+
+    return (
+        f"implausible PV level: peak {peak_power_w / 1000:.1f} kW for unit '{unit}', "
+        f"but only {installed_power_w / 1000:.1f} kW is installed. If the source "
+        f"reports power rather than energy per slot, set the unit to 'W' or 'kW'."
+    )
+
+
+def price_plausibility_message(values_eur_per_wh, unit):
+    """
+    Check converted prices against a plausible tariff band.
+
+    Uses the median so that a handful of negative or zero spot hours cannot trip the
+    check, while a wholesale unit mistake — which shifts every value — does.
+
+    Args:
+        values_eur_per_wh: Converted price values.
+        unit: The configured unit, named in the message.
+
+    Returns:
+        str: A user-facing warning, or None when the prices look plausible.
+    """
+    if not values_eur_per_wh:
+        return None
+
+    median_ct_kwh = _median([abs(v) for v in values_eur_per_wh]) * 100_000
+    if PRICE_PLAUSIBLE_MIN_CT_KWH <= median_ct_kwh <= PRICE_PLAUSIBLE_MAX_CT_KWH:
+        return None
+
+    if median_ct_kwh > PRICE_PLAUSIBLE_MAX_CT_KWH:
+        hint = (
+            f"values look about 1000x too high for unit '{unit}' — the source is "
+            f"probably already in EUR/Wh, or in ct/kWh"
+        )
+    else:
+        hint = (
+            f"values look about 1000x too low for unit '{unit}' — the source is "
+            f"probably in EUR/kWh"
+        )
+
+    return (
+        f"implausible price level: median {median_ct_kwh:.1f} ct/kWh, expected "
+        f"{PRICE_PLAUSIBLE_MIN_CT_KWH}-{PRICE_PLAUSIBLE_MAX_CT_KWH} ct/kWh. {hint}"
+    )
+
+
+def extract_json_path(obj, path, label="timeseries"):
+    """
+    Extract a nested value from a decoded JSON payload using dot notation.
+
+    Examples:
+    - 'attributes.data' -> obj['attributes']['data']
+    - 'data'            -> obj['data']
+    - 'prices[0].data'  -> obj['prices'][0]['data']
+
+    Shared by the price interface, the PV interface and the config-web probe so the
+    pre-flight test resolves exactly the same path the running interface will.
+
+    Args:
+        obj: JSON object (dict or list)
+        path: Dot-notation path string
+        label: Prefix used in log messages, e.g. "PRICE-IF" or "PV-IF".
+
+    Returns:
+        Extracted value, or None if the path does not resolve.
+    """
+    try:
+        current = obj
+        for part in path.split("."):
+            if "[" in part:
+                # Handle array index notation (e.g., "prices[0]")
+                key, index_str = part.split("[")
+                index = int(index_str.rstrip("]"))
+                if key:
+                    current = current[key][index]
+                else:
+                    current = current[index]
+            else:
+                current = current[part]
+        return current
+    except (KeyError, IndexError, TypeError, ValueError):
+        logger.warning("[%s] Could not extract path '%s' from JSON response", label, path)
+        return None

--- a/src/web/css/config.css
+++ b/src/web/css/config.css
@@ -349,6 +349,80 @@
     text-decoration: underline;
 }
 
+/* --- Timeseries connection test --- */
+.config-timeseries-tester .config-btn {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: #ccc;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.config-timeseries-tester .config-btn:hover:not(:disabled) {
+    background-color: rgba(255, 255, 255, 0.18);
+}
+
+.config-timeseries-tester .config-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.config-timeseries-result {
+    display: none;
+    width: 100%;
+    font-size: 0.82em;
+    line-height: 1.5;
+    color: #ccc;
+    margin-top: 8px;
+    padding: 10px 12px;
+    border-radius: 6px;
+    border-left: 3px solid rgba(255, 255, 255, 0.2);
+    background-color: rgba(0, 0, 0, 0.18);
+}
+
+.config-timeseries-result.visible {
+    display: block;
+}
+
+.config-timeseries-result.ok {
+    border-left-color: #4caf50;
+}
+
+.config-timeseries-result.ok .fa-circle-check {
+    color: #4caf50;
+}
+
+.config-timeseries-result.error {
+    border-left-color: #ff6b6b;
+    color: #ffb3b3;
+}
+
+.config-timeseries-result.error .fa-times-circle {
+    color: #ff6b6b;
+}
+
+/* The sample slots are the point of the test: they show the converted value in the
+   same unit the schedule uses, so a wrong value_unit is visible before saving. */
+.config-timeseries-slots {
+    margin-top: 8px;
+    border-collapse: collapse;
+    font-family: "Courier New", monospace;
+    font-size: 0.95em;
+}
+
+.config-timeseries-slots td {
+    padding: 2px 10px 2px 0;
+    color: #ddd;
+    white-space: nowrap;
+}
+
+.config-timeseries-warning {
+    margin-top: 8px;
+    color: #ffc107;
+}
+
+.config-timeseries-warning .fa-triangle-exclamation {
+    margin-right: 4px;
+}
+
 /* --- Level switcher --- */
 .config-level-select {
     padding: 5px 10px;

--- a/src/web/js/config.js
+++ b/src/web/js/config.js
@@ -419,6 +419,7 @@ class ConfigurationManager {
                 html += `<div class="config-group${allHidden ? ' hidden' : ''}" data-group="${groupName}" data-subsection="${subsection}">
                     <div class="config-group-title">${groupName}</div>
                     ${groupFields.map(f => this._renderField(f)).join("")}
+                    ${this._renderTimeseriesTester(groupFields)}
                 </div>`;
             } else {
                 html += groupFields.map(f => this._renderField(f)).join("");
@@ -1094,7 +1095,34 @@ class ConfigurationManager {
             }
         }
 
+        this._updateTimeseriesTesterVisibility();
         this._updateGroupVisibility();
+    }
+
+    /**
+     * Show or hide the "Test connection" panels alongside their timeseries fields.
+     *
+     * The panels are not schema fields, so the depends_on loop above does not reach
+     * them; without this they would keep the visibility they had at render time and
+     * stay behind after a source switch.
+     */
+    _updateTimeseriesTesterVisibility() {
+        if (!this.schema) {
+            return;
+        }
+        for (const el of document.querySelectorAll("[data-timeseries-tester]")) {
+            const domain = el.getAttribute("data-timeseries-tester");
+            const section = domain === "price" ? "price" : "pv_forecast_source";
+            const unitField = this.schema.find(f => f.key === `${section}.value_unit`);
+            if (!unitField) {
+                continue;
+            }
+            if (this._isDependencyHidden(unitField)) {
+                el.classList.add("hidden");
+            } else {
+                el.classList.remove("hidden");
+            }
+        }
     }
 
     /**
@@ -1810,6 +1838,129 @@ class ConfigurationManager {
     }
 
     // ── Utility ─────────────────────────────────────────────────
+
+    /**
+     * Render the "Test connection" panel for a group holding timeseries fields.
+     *
+     * The timeseries source accepts exactly one format, so the user needs to see what
+     * their source actually yields: a payload can match the format perfectly and still
+     * be off by a factor of 1000 if the unit is wrong. Showing the first slots in the
+     * unit displayed elsewhere in the UI makes that visible before saving.
+     *
+     * @param {Array<Object>} groupFields - Fields rendered in this group
+     * @returns {string} Panel HTML, or "" when the group has no timeseries fields
+     */
+    _renderTimeseriesTester(groupFields) {
+        const unitField = groupFields.find(f => f.key.endsWith(".value_unit"));
+        if (!unitField) {
+            return "";
+        }
+        const section = unitField.key.split(".")[0];
+        const domain = section === "price" ? "price" : "pv";
+        const hidden = this._isDependencyHidden(unitField) ? " hidden" : "";
+
+        return `
+            <div class="config-field config-timeseries-tester${hidden}" data-timeseries-tester="${domain}">
+                <div class="config-field-label"><span>Connection test</span></div>
+                <div class="config-field-input">
+                    <button type="button" class="config-btn"
+                            id="cfg-ts-test-${domain}"
+                            onclick="configurationManager.testTimeseries('${domain}')">
+                        <i class="fas fa-plug"></i> Test connection
+                    </button>
+                </div>
+                <div class="config-timeseries-result" id="cfg-ts-result-${domain}"></div>
+            </div>`;
+    }
+
+    /**
+     * Probe the configured timeseries source and render the outcome.
+     *
+     * Sends the values currently in the form (not just the saved ones) so the user can
+     * test before committing.
+     *
+     * @param {string} domain - "price" or "pv"
+     */
+    async testTimeseries(domain) {
+        const section = domain === "price" ? "price" : "pv_forecast_source";
+        const resultEl = document.getElementById(`cfg-ts-result-${domain}`);
+        const btnEl = document.getElementById(`cfg-ts-test-${domain}`);
+        if (!resultEl) {
+            return;
+        }
+
+        const body = { domain };
+        for (const suffix of [
+            "source", "data_url", "data_path", "data_token",
+            "value_unit", "use_ha_central_data_source", "ha_sensor_name",
+        ]) {
+            const key = `${section}.${suffix}`;
+            if (this.values[key] !== undefined) {
+                body[key] = this.values[key];
+            }
+        }
+        for (const key of ["data_source.url", "data_source.access_token"]) {
+            if (this.values[key] !== undefined) {
+                body[key] = this.values[key];
+            }
+        }
+
+        resultEl.className = "config-timeseries-result visible";
+        resultEl.innerHTML = `<i class="fas fa-spinner fa-spin"></i> Testing…`;
+        if (btnEl) {
+            btnEl.disabled = true;
+        }
+
+        try {
+            const res = await fetch("api/config/test-timeseries", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+            });
+            const data = await res.json();
+            resultEl.innerHTML = this._renderTimeseriesResult(data);
+            resultEl.className = `config-timeseries-result visible ${data.ok ? "ok" : "error"}`;
+        } catch (err) {
+            console.error("[ConfigurationManager] Timeseries test failed:", err);
+            resultEl.className = "config-timeseries-result visible error";
+            resultEl.innerHTML = `<i class="fas fa-times-circle"></i> Test request failed.`;
+        } finally {
+            if (btnEl) {
+                btnEl.disabled = false;
+            }
+        }
+    }
+
+    /**
+     * Turn a probe result into readable HTML.
+     * @param {Object} data - Probe response
+     * @returns {string} Result HTML
+     */
+    _renderTimeseriesResult(data) {
+        if (!data.ok) {
+            return `<i class="fas fa-times-circle"></i> ${this._escapeHtml(data.error || "Test failed.")}`;
+        }
+
+        const resolution = data.resolution_seconds === 900 ? "15 min" : "hourly";
+        const slots = (data.slots || []).map(slot => {
+            const time = String(slot.start || "").replace("T", " ").slice(0, 16);
+            return `<tr><td>${this._escapeHtml(time)}</td>
+                        <td style="text-align:right;">${slot.value}</td>
+                        <td>${this._escapeHtml(slot.unit)}</td></tr>`;
+        }).join("");
+
+        const warnings = (data.warnings || []).map(
+            w => `<div class="config-timeseries-warning">
+                    <i class="fas fa-triangle-exclamation"></i> ${this._escapeHtml(w)}
+                  </div>`
+        ).join("");
+
+        return `<div><i class="fas fa-circle-check"></i>
+                    ${data.entry_count} entries, ${resolution} resolution,
+                    read as ${this._escapeHtml(data.value_unit)}</div>
+                <table class="config-timeseries-slots">${slots}</table>
+                ${warnings}`;
+    }
 
     /**
      * Convert a dot-notation key to a CSS-safe id fragment.

--- a/tests/config_web/test_api_timeseries.py
+++ b/tests/config_web/test_api_timeseries.py
@@ -1,0 +1,569 @@
+"""
+Tests for the timeseries endpoint and the save-time pre-flight.
+
+Two properties matter here: the documented POST /api/config/test-timeseries endpoint
+exists and reports what a source yields, and saving an unrelated setting does not fire
+a network probe (which would make every save depend on a reachable endpoint).
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from src.config_web.api import config_bp, init_api
+from src.config_web.merger import build_merged_config
+from src.config_web.migration import migrate_yaml_to_store
+from src.config_web.schema import ConfigSchema
+from src.config_web.store import ConfigStore
+
+from .test_api import _FakeModule, _sample_config
+
+EVCC_RATES = {
+    "rates": [
+        {"start": "2026-08-23T00:00:00+02:00", "value": 0.3811},
+        {"start": "2026-08-23T00:15:00+02:00", "value": 0.3727},
+    ]
+}
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture(name="client")
+def client_fixture(tmp_path):
+    """Flask client whose price source is already set to timeseries."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    schema = ConfigSchema()
+    store = ConfigStore(str(tmp_path / "test.db"))
+    store.open()
+
+    config = _sample_config()
+    migrate_yaml_to_store(config, store, schema)
+    store.set("price.source", "timeseries")
+    store.set("price.data_url", "http://evcc.local/api/tariff/grid")
+    store.set("price.data_path", "rates")
+    store.set("price.value_unit", "EUR/kWh")
+
+    module = _FakeModule(config, store, schema)
+    init_api(store, schema, module)
+    app.register_blueprint(config_bp)
+
+    with app.test_client() as c:
+        c.store = store
+        yield c
+
+    store.close()
+
+
+def post_test_timeseries(client, body=None, payload=EVCC_RATES, status_code=200):
+    with patch(
+        "src.config_web.timeseries_probe.requests.get",
+        return_value=FakeResponse(payload, status_code),
+    ) as mock_get:
+        resp = client.post(
+            "/api/config/test-timeseries",
+            data=json.dumps(body or {}),
+            content_type="application/json",
+        )
+    return resp, mock_get
+
+
+class TestTestTimeseriesEndpoint:
+    """The endpoint the docs have described all along."""
+
+    def test_endpoint_exists_and_reports_a_healthy_source(self, client):
+        resp, _ = post_test_timeseries(client)
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert data["entry_count"] == 2
+        assert data["resolution_seconds"] == 900
+
+    def test_reports_converted_values_in_display_units(self, client):
+        resp, _ = post_test_timeseries(client)
+
+        first = resp.get_json()["slots"][0]
+        assert first["unit"] == "ct/kWh"
+        assert first["value"] == pytest.approx(38.11, abs=0.01)
+
+    def test_unsaved_values_from_the_form_are_honoured(self, client):
+        """The UI tests what the user typed, before it is saved."""
+        resp, mock_get = post_test_timeseries(
+            client, {"price.data_url": "http://other.local/api/tariff/grid"}
+        )
+
+        assert resp.status_code == 200
+        assert mock_get.call_args[0][0] == "http://other.local/api/tariff/grid"
+
+    def test_unsaved_unit_change_is_honoured_and_warns(self, client):
+        resp, _ = post_test_timeseries(client, {"price.value_unit": "EUR/Wh"})
+
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert any("implausible" in w for w in data["warnings"])
+
+    def test_failure_is_reported_as_a_result_not_a_server_error(self, client):
+        resp, _ = post_test_timeseries(client, payload={}, status_code=404)
+
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is False
+
+    def test_pv_domain_supported(self, client):
+        payload = {"attributes": {"data": [
+            {"start": "2026-08-23T00:00:00+02:00", "value": 4000.0},
+            {"start": "2026-08-23T00:15:00+02:00", "value": 4000.0},
+        ]}}
+        resp, _ = post_test_timeseries(
+            client,
+            {
+                "domain": "pv",
+                "pv_forecast_source.source": "timeseries",
+                "pv_forecast_source.data_url": "http://ha.local/api/states/sensor.pv",
+                "pv_forecast_source.data_path": "attributes.data",
+                "pv_forecast_source.value_unit": "W",
+            },
+            payload=payload,
+        )
+
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert data["slots"][0]["unit"] == "Wh"
+
+    def test_unknown_domain_rejected(self, client):
+        resp = client.post(
+            "/api/config/test-timeseries",
+            data=json.dumps({"domain": "weather"}),
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 400
+
+
+class TestPreflightScope:
+    """A save must not depend on an endpoint it has no reason to contact."""
+
+    def test_unrelated_setting_change_does_not_probe(self, client):
+        with patch("src.config_web.timeseries_probe.requests.get") as mock_get:
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"battery.min_soc_percentage": 12}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        mock_get.assert_not_called()
+
+    def test_timeseries_field_change_does_probe(self, client):
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            return_value=FakeResponse(EVCC_RATES),
+        ) as mock_get:
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"price.data_path": "rates"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        mock_get.assert_called_once()
+
+    def test_broken_source_blocks_the_save_against_the_right_field(self, client):
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            return_value=FakeResponse({"rates": [{"start_time": "x", "price_per_kwh": 1}]}),
+        ):
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"price.data_path": "rates"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 422
+        errors = resp.get_json()["errors"]
+        assert errors[0]["key"] == "price.data_path"
+        assert "'start_time'" in errors[0]["error"]
+
+    def test_a_unit_warning_does_not_block_the_save(self, client):
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            return_value=FakeResponse(EVCC_RATES),
+        ):
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"price.value_unit": "EUR/Wh"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+
+
+class TestCentralModeResolution:
+    """
+    The probe must resolve the connection exactly as the running interface will.
+
+    The merged config is not a safe source for data_url/data_token: the merger
+    overwrites them with values derived from the central data source, so a request
+    that switches central mode off would otherwise be probed against the stale
+    derived URL.
+    """
+
+    def _central_client(self, tmp_path):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        schema = ConfigSchema()
+        store = ConfigStore(str(tmp_path / "central.db"))
+        store.open()
+        config = _sample_config()
+        migrate_yaml_to_store(config, store, schema)
+        store.set("price.source", "timeseries")
+        store.set("price.use_ha_central_data_source", True)
+        store.set("price.ha_sensor_name", "sensor.grid_prices")
+        store.set("price.data_path", "attributes.data")
+        store.set("price.data_url", "http://direct.local/prices")
+        store.set("data_source.url", "http://ha.local:8123")
+        store.set("data_source.access_token", "tok")
+        module = _FakeModule(config, store, schema)
+        init_api(store, schema, module)
+        app.register_blueprint(config_bp)
+        return app, store
+
+    def test_central_mode_probes_the_derived_sensor_url(self, tmp_path):
+        app, store = self._central_client(tmp_path)
+        payload = {"attributes": {"data": EVCC_RATES["rates"]}}
+
+        with app.test_client() as client:
+            with patch(
+                "src.config_web.timeseries_probe.requests.get",
+                return_value=FakeResponse(payload),
+            ) as mock_get:
+                client.post(
+                    "/api/config/test-timeseries",
+                    data=json.dumps({}),
+                    content_type="application/json",
+                )
+
+        assert mock_get.call_args[0][0] == "http://ha.local:8123/api/states/sensor.grid_prices"
+        store.close()
+
+    def test_switching_central_off_probes_the_users_own_url(self, tmp_path):
+        app, store = self._central_client(tmp_path)
+
+        with app.test_client() as client:
+            with patch(
+                "src.config_web.timeseries_probe.requests.get",
+                return_value=FakeResponse({"rates": EVCC_RATES["rates"]}),
+            ) as mock_get:
+                client.post(
+                    "/api/config/test-timeseries",
+                    data=json.dumps(
+                        {
+                            "price.use_ha_central_data_source": False,
+                            "price.data_path": "rates",
+                        }
+                    ),
+                    content_type="application/json",
+                )
+
+        assert mock_get.call_args[0][0] == "http://direct.local/prices"
+        store.close()
+
+    def test_central_url_is_built_the_same_way_the_merger_builds_it(self, tmp_path):
+        """
+        Parity check against merger._apply_central_ha_data_source.
+
+        If the two ever diverge the probe would validate a URL the interface never
+        fetches, which is worse than having no probe at all.
+        """
+        app, store = self._central_client(tmp_path)
+        schema = ConfigSchema()
+        config = _sample_config()
+        merged = build_merged_config(config, store, schema)
+        expected = merged["price"]["data_url"]
+
+        with app.test_client() as client:
+            with patch(
+                "src.config_web.timeseries_probe.requests.get",
+                return_value=FakeResponse({"attributes": {"data": EVCC_RATES["rates"]}}),
+            ) as mock_get:
+                client.post(
+                    "/api/config/test-timeseries",
+                    data=json.dumps({}),
+                    content_type="application/json",
+                )
+
+        assert mock_get.call_args[0][0] == expected
+        store.close()
+
+
+class TestPreflightTriggerScope:
+    """The shared data source may only trigger a domain that opted into it."""
+
+    def test_data_source_edit_does_not_probe_a_non_central_domain(self, client):
+        with patch("src.config_web.timeseries_probe.requests.get") as mock_get:
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"data_source.url": "http://ha.local:8123"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        mock_get.assert_not_called()
+
+    def test_data_source_edit_does_probe_a_central_domain(self, client):
+        client.store.set("price.use_ha_central_data_source", True)
+        client.store.set("price.data_path", "attributes.data")
+
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            return_value=FakeResponse({"attributes": {"data": EVCC_RATES["rates"]}}),
+        ) as mock_get:
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"data_source.url": "http://ha.local:8123"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        mock_get.assert_called_once()
+
+
+class TestPreflightRobustness:
+    """Pre-flight guards against misconfiguration — not against a source being down."""
+
+    def test_unreachable_endpoint_does_not_block_the_save(self, client):
+        import requests as _requests
+
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            side_effect=_requests.exceptions.ConnectionError("down"),
+        ):
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"price.data_path": "rates"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+
+    def test_switching_source_on_does_not_block_on_the_placeholder_url(self, client):
+        import requests as _requests
+
+        client.store.set("price.source", "default")
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            side_effect=_requests.exceptions.Timeout(),
+        ):
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"price.source": "timeseries"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+
+    def test_a_bad_format_still_blocks(self, client):
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            return_value=FakeResponse({"rates": [{"nope": 1}]}),
+        ):
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"price.data_path": "rates"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 422
+
+    def test_string_false_is_not_treated_as_central_mode(self, client):
+        """
+        Pre-flight runs before _coerce_value, so the raw body may carry "false".
+
+        Truthiness-testing it would send the probe down the central-HA branch and
+        reject a perfectly valid direct-URL save.
+        """
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            return_value=FakeResponse(EVCC_RATES),
+        ) as mock_get:
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps(
+                    {
+                        "price.use_ha_central_data_source": "false",
+                        "price.data_path": "rates",
+                    }
+                ),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        assert mock_get.call_args[0][0] == "http://evcc.local/api/tariff/grid"
+
+
+class TestEffectiveTimeFrame:
+    """
+    The probe must judge resolution against the slot length actually used.
+
+    eos_connect forces 900 back to 3600 unless an EVopt backend is selected, so taking
+    eos.time_frame verbatim would reject hourly sources on systems that run hourly.
+    """
+
+    HOURLY_PAYLOAD = {
+        "rates": [
+            {"start": "2026-08-23T00:00:00+02:00", "value": 0.30},
+            {"start": "2026-08-23T01:00:00+02:00", "value": 0.31},
+        ]
+    }
+
+    def test_hourly_source_accepted_when_900_is_not_actually_honoured(self, client):
+        client.store.set("eos.time_frame", 900)
+        client.store.set("eos.source", "eos_server")
+
+        resp, _ = post_test_timeseries(client, payload=self.HOURLY_PAYLOAD)
+
+        assert resp.get_json()["ok"] is True
+
+    def test_hourly_source_rejected_when_900_really_applies(self, client):
+        client.store.set("eos.time_frame", 900)
+        client.store.set("eos.source", "local_evopt")
+
+        resp, _ = post_test_timeseries(client, payload=self.HOURLY_PAYLOAD)
+
+        data = resp.get_json()
+        assert data["ok"] is False
+        assert "15-minute slots" in data["error"]
+
+
+class TestConnectionFieldResolution:
+    """
+    The probe must resolve data_url/data_token from what the user set, never from the
+    merger's central-HA derivation.
+    """
+
+    def _client_with_central_only(self, tmp_path):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        schema = ConfigSchema()
+        store = ConfigStore(str(tmp_path / "leak.db"))
+        store.open()
+        config = _sample_config()
+        migrate_yaml_to_store(config, store, schema)
+        store.set("price.source", "timeseries")
+        store.set("price.use_ha_central_data_source", True)
+        store.set("price.ha_sensor_name", "sensor.grid_prices")
+        store.set("data_source.url", "http://ha.local:8123")
+        store.set("data_source.access_token", "ha-token")
+        # price.data_url deliberately never written: only the schema default exists.
+        module = _FakeModule(config, store, schema)
+        init_api(store, schema, module)
+        app.register_blueprint(config_bp)
+        return app, store
+
+    def test_turning_central_off_does_not_reuse_the_derived_url(self, tmp_path):
+        app, store = self._client_with_central_only(tmp_path)
+
+        with app.test_client() as client:
+            with patch(
+                "src.config_web.timeseries_probe.requests.get",
+                return_value=FakeResponse({"attributes": {"data": EVCC_RATES["rates"]}}),
+            ) as mock_get:
+                client.post(
+                    "/api/config/test-timeseries",
+                    data=json.dumps({"price.use_ha_central_data_source": False}),
+                    content_type="application/json",
+                )
+
+        # Must not be built from data_source.url; falling back to the schema default
+        # for price.data_url is correct here.
+        probed_url = mock_get.call_args[0][0]
+        assert "ha.local:8123" not in probed_url
+        store.close()
+
+    def test_turning_central_off_does_not_reuse_the_ha_token(self, tmp_path):
+        app, store = self._client_with_central_only(tmp_path)
+
+        with app.test_client() as client:
+            with patch(
+                "src.config_web.timeseries_probe.requests.get",
+                return_value=FakeResponse({"attributes": {"data": EVCC_RATES["rates"]}}),
+            ) as mock_get:
+                client.post(
+                    "/api/config/test-timeseries",
+                    data=json.dumps({"price.use_ha_central_data_source": False}),
+                    content_type="application/json",
+                )
+
+        headers = mock_get.call_args[1]["headers"]
+        assert "ha-token" not in headers.get("Authorization", "")
+        store.close()
+
+    def test_empty_sensor_name_is_not_silently_defaulted(self, tmp_path):
+        """
+        The merger passes an empty entity through, producing '/api/states/'.
+
+        Substituting a default here would test a URL the interface never fetches.
+        """
+        app, store = self._client_with_central_only(tmp_path)
+        store.set("price.ha_sensor_name", "")
+
+        with app.test_client() as client:
+            with patch(
+                "src.config_web.timeseries_probe.requests.get",
+                return_value=FakeResponse({}, 404),
+            ) as mock_get:
+                client.post(
+                    "/api/config/test-timeseries",
+                    data=json.dumps({}),
+                    content_type="application/json",
+                )
+
+        assert mock_get.call_args[0][0] == "http://ha.local:8123/api/states/"
+        store.close()
+
+
+class TestSharedDataSourceEditsAreNotBlocked:
+    """Rotating the HA token must not depend on every domain's sensor being healthy."""
+
+    def test_broken_central_domain_does_not_block_a_token_rotation(self, client):
+        client.store.set("price.use_ha_central_data_source", True)
+        client.store.set("price.ha_sensor_name", "sensor.deleted")
+        client.store.set("price.data_path", "attributes.data")
+
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            return_value=FakeResponse({}, 404),
+        ):
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"data_source.access_token": "new-token"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+
+    def test_editing_the_domains_own_field_still_blocks(self, client):
+        client.store.set("price.use_ha_central_data_source", True)
+        client.store.set("price.data_path", "attributes.data")
+
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            return_value=FakeResponse({}, 404),
+        ):
+            resp = client.put(
+                "/api/config/",
+                data=json.dumps({"price.ha_sensor_name": "sensor.deleted"}),
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 422

--- a/tests/config_web/test_timeseries_probe.py
+++ b/tests/config_web/test_timeseries_probe.py
@@ -1,0 +1,345 @@
+"""
+Tests for the timeseries pre-flight probe.
+
+The probe is what makes a deliberately strict format workable: it has to say why a
+source was rejected, and — for a source it accepts — show the converted numbers so a
+unit mistake is visible before saving rather than hours later in the schedule.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from src.config_web.timeseries_probe import probe
+
+EVCC_RATES = {
+    "rates": [
+        {"start": "2026-08-23T00:00:00+02:00", "end": "2026-08-23T00:15:00+02:00", "value": 0.3811},
+        {"start": "2026-08-23T00:15:00+02:00", "end": "2026-08-23T00:30:00+02:00", "value": 0.3727},
+        {"start": "2026-08-23T00:30:00+02:00", "end": "2026-08-23T00:45:00+02:00", "value": 0.3668},
+    ]
+}
+
+
+class FakeResponse:
+    def __init__(self, payload=None, status_code=200, raise_json=False):
+        self._payload = payload
+        self.status_code = status_code
+        self._raise_json = raise_json
+
+    def json(self):
+        if self._raise_json:
+            raise ValueError("not json")
+        return self._payload
+
+
+def run_probe(payload=None, status_code=200, raise_json=False, **kwargs):
+    params = {
+        "domain": "price",
+        "data_url": "http://evcc.local/api/tariff/grid",
+        "data_path": "rates",
+        "data_token": "",
+        "value_unit": "EUR/kWh",
+        "time_zone": "Europe/Berlin",
+    }
+    params.update(kwargs)
+    with patch(
+        "src.config_web.timeseries_probe.requests.get",
+        return_value=FakeResponse(payload, status_code, raise_json),
+    ):
+        return probe(**params)
+
+
+class TestSuccessfulProbe:
+    def test_reports_shape_and_converted_values(self):
+        result = run_probe(EVCC_RATES)
+
+        assert result["ok"] is True
+        assert result["entry_count"] == 3
+        assert result["resolution_seconds"] == 900
+        assert result["value_unit"] == "EUR/kWh"
+
+    def test_slots_are_rendered_in_the_unit_the_ui_shows(self):
+        result = run_probe(EVCC_RATES)
+
+        first = result["slots"][0]
+        assert first["unit"] == "ct/kWh"
+        assert first["value"] == pytest.approx(38.11, abs=0.01)
+
+    def test_slot_timestamps_are_resolved_so_an_offset_problem_is_visible(self):
+        result = run_probe(EVCC_RATES)
+
+        assert result["slots"][0]["start"].startswith("2026-08-23T00:00:00")
+        assert result["slots"][0]["end"] is not None
+
+    def test_pv_values_reported_in_watt_hours(self):
+        payload = {
+            "attributes": {
+                "data": [
+                    {"start": "2026-08-23T00:00:00+02:00", "value": 4000.0},
+                    {"start": "2026-08-23T00:15:00+02:00", "value": 4000.0},
+                ]
+            }
+        }
+
+        result = run_probe(
+            payload,
+            domain="pv",
+            data_path="attributes.data",
+            value_unit="W",
+        )
+
+        assert result["ok"] is True
+        assert result["slots"][0]["unit"] == "Wh"
+        assert result["slots"][0]["value"] == pytest.approx(1000.0)
+
+
+class TestUnitMistakeIsSurfaced:
+    """Tobias' case: the format is right, the unit is not."""
+
+    def test_evcc_payload_read_as_eur_per_wh_warns_without_failing(self):
+        result = run_probe(EVCC_RATES, value_unit="EUR/Wh")
+
+        assert result["ok"] is True
+        assert any("implausible price level" in w for w in result["warnings"])
+
+    def test_the_warning_shows_the_absurd_number(self):
+        result = run_probe(EVCC_RATES, value_unit="EUR/Wh")
+
+        assert result["slots"][0]["value"] == pytest.approx(38110.0, abs=1.0)
+
+    def test_correct_unit_produces_no_warning(self):
+        result = run_probe(EVCC_RATES)
+
+        assert result["warnings"] == []
+
+    def test_unknown_unit_is_rejected_against_the_unit_field(self):
+        result = run_probe(EVCC_RATES, value_unit="USD/kWh")
+
+        assert result["ok"] is False
+        assert result["field"] == "price.value_unit"
+
+
+class TestFormatMismatch:
+    def test_foreign_field_names_named_against_the_path_field(self):
+        payload = {
+            "data": [
+                {"start_time": "2026-08-23T00:00:00+02:00", "price_per_kwh": 0.3811}
+            ]
+        }
+
+        result = run_probe(payload, data_path="data")
+
+        assert result["ok"] is False
+        assert result["field"] == "price.data_path"
+        assert "'start_time'" in result["error"]
+
+    def test_wrong_path_lists_the_top_level_keys(self):
+        result = run_probe(EVCC_RATES, data_path="prices")
+
+        assert result["ok"] is False
+        assert result["field"] == "price.data_path"
+        assert "'rates'" in result["error"]
+
+    def test_unsupported_resolution_is_named(self):
+        payload = {
+            "rates": [
+                {"start": "2026-08-23T00:00:00+02:00", "value": 0.30},
+                {"start": "2026-08-23T00:05:00+02:00", "value": 0.31},
+            ]
+        }
+
+        result = run_probe(payload)
+
+        assert result["ok"] is False
+        assert "300s" in result["error"]
+
+    def test_single_entry_cannot_determine_resolution(self):
+        payload = {"rates": [{"start": "2026-08-23T00:00:00+02:00", "value": 0.30}]}
+
+        result = run_probe(payload)
+
+        assert result["ok"] is False
+        assert "at least two" in result["error"]
+
+    def test_naive_timestamps_are_warned_about(self):
+        payload = {
+            "rates": [
+                {"start": "2026-08-23 00:00:00", "value": 0.30},
+                {"start": "2026-08-23 00:15:00", "value": 0.31},
+            ]
+        }
+
+        result = run_probe(payload)
+
+        assert result["ok"] is True
+        assert any("no UTC offset" in w for w in result["warnings"])
+
+
+class TestTransportFailures:
+    """Curated messages only — no exception text reaches the client."""
+
+    def test_404_names_the_resource(self):
+        result = run_probe({}, status_code=404, resource_label="sensor.grid_prices")
+
+        assert result["ok"] is False
+        assert "sensor.grid_prices" in result["error"]
+
+    def test_401_points_at_the_token(self):
+        result = run_probe({}, status_code=401)
+
+        assert result["ok"] is False
+        assert "token" in result["error"].lower()
+
+    def test_500_reports_the_status(self):
+        result = run_probe({}, status_code=500)
+
+        assert result["ok"] is False
+        assert "500" in result["error"]
+
+    def test_raised_http_error_carrying_a_response_is_mapped(self):
+        exc = requests.exceptions.HTTPError()
+        exc.response = type("R", (object,), {"status_code": 404})()
+
+        with patch(
+            "src.config_web.timeseries_probe.requests.get", side_effect=exc
+        ):
+            result = probe(
+                "price",
+                "http://ha.local/api/states/sensor.x",
+                "attributes.data",
+                "",
+                "EUR/kWh",
+                "UTC",
+                resource_label="sensor.x",
+            )
+
+        assert result["ok"] is False
+        assert "sensor.x" in result["error"]
+
+    def test_timeout_is_reported_plainly(self):
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            side_effect=requests.exceptions.Timeout(),
+        ):
+            result = probe(
+                "price", "http://x.local", "rates", "", "EUR/kWh", "UTC"
+            )
+
+        assert result["ok"] is False
+        assert "No response within" in result["error"]
+
+    def test_connection_error_does_not_leak_exception_text(self):
+        with patch(
+            "src.config_web.timeseries_probe.requests.get",
+            side_effect=requests.exceptions.ConnectionError("secret-internal-host:5432"),
+        ):
+            result = probe(
+                "price", "http://x.local", "rates", "", "EUR/kWh", "UTC"
+            )
+
+        assert result["ok"] is False
+        assert "secret-internal-host" not in result["error"]
+
+    def test_non_json_response_is_reported(self):
+        result = run_probe(None, raise_json=True)
+
+        assert result["ok"] is False
+        assert "JSON" in result["error"]
+
+    def test_missing_url_is_reported_without_a_request(self):
+        result = probe("price", "", "rates", "", "EUR/kWh", "UTC")
+
+        assert result["ok"] is False
+        assert result["field"] == "price.data_url"
+
+    def test_unknown_domain_rejected(self):
+        result = probe("weather", "http://x", "d", "", "EUR/kWh", "UTC")
+
+        assert result["ok"] is False
+
+
+class TestResolutionCompatibility:
+    """A green test must not be followed by a runtime "resolution mismatch"."""
+
+    def test_hourly_source_on_15min_system_is_rejected(self):
+        payload = {
+            "rates": [
+                {"start": "2026-08-23T00:00:00+02:00", "value": 0.30},
+                {"start": "2026-08-23T01:00:00+02:00", "value": 0.31},
+            ]
+        }
+
+        result = run_probe(payload, time_frame_base=900)
+
+        assert result["ok"] is False
+        assert "15-minute slots" in result["error"]
+
+    def test_quarter_hourly_source_on_15min_system_is_fine(self):
+        result = run_probe(EVCC_RATES, time_frame_base=900)
+
+        assert result["ok"] is True
+
+    def test_hourly_source_on_hourly_system_is_fine(self):
+        payload = {
+            "rates": [
+                {"start": "2026-08-23T00:00:00+02:00", "value": 0.30},
+                {"start": "2026-08-23T01:00:00+02:00", "value": 0.31},
+            ]
+        }
+
+        result = run_probe(payload, time_frame_base=3600)
+
+        assert result["ok"] is True
+
+
+class TestPvPlausibility:
+    """The PV unit mistake is only a factor of four — it needs a reference to be seen."""
+
+    PV_PAYLOAD = {
+        "attributes": {
+            "data": [
+                {"start": "2026-08-23T12:00:00+02:00", "value": 4000.0},
+                {"start": "2026-08-23T12:15:00+02:00", "value": 4000.0},
+            ]
+        }
+    }
+
+    def _pv_probe(self, **kwargs):
+        return run_probe(
+            self.PV_PAYLOAD,
+            domain="pv",
+            data_path="attributes.data",
+            value_unit="W",
+            **kwargs,
+        )
+
+    def test_matching_installation_produces_no_warning(self):
+        result = self._pv_probe(installed_power_w=4000)
+
+        assert result["ok"] is True
+        assert result["warnings"] == []
+
+    def test_energy_unit_on_a_power_source_is_flagged(self):
+        result = run_probe(
+            self.PV_PAYLOAD,
+            domain="pv",
+            data_path="attributes.data",
+            value_unit="Wh",
+            installed_power_w=4000,
+        )
+
+        assert result["ok"] is True
+        assert any("implausible PV level" in w for w in result["warnings"])
+
+    def test_without_a_configured_installation_no_guessing(self):
+        result = run_probe(
+            self.PV_PAYLOAD,
+            domain="pv",
+            data_path="attributes.data",
+            value_unit="Wh",
+            installed_power_w=0,
+        )
+
+        assert result["warnings"] == []

--- a/tests/interfaces/price/scenarios/test_issue_214_payloads.py
+++ b/tests/interfaces/price/scenarios/test_issue_214_payloads.py
@@ -1,0 +1,349 @@
+# pylint: disable=protected-access
+"""
+End-to-end parsing of the payloads reported in discussion #214.
+
+The canonical timeseries format is EVCC's, because that is the format users already
+have — either straight from an EVCC endpoint or from a Home Assistant template sensor
+written to feed EVCC. These tests use the payloads from the thread verbatim so the
+reported symptoms stay pinned:
+
+  - EVCC /api/tariff/grid was read as EUR/Wh and rendered 34660 ct/kWh
+  - Tibber / EPEX HA integrations were rejected outright over field names
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.interfaces.price_interface import PriceInterface
+
+# Values quoted in the discussion, in EUR/kWh.
+TIBBER_PRICES_EUR_KWH = [0.3811, 0.3727, 0.3668]
+
+
+@pytest.fixture(name="price_interface")
+def fixture_price_interface(monkeypatch):
+    """Price interface configured for the unified timeseries source."""
+    monkeypatch.setattr(
+        "src.interfaces.price_interface.PriceInterface._PriceInterface__start_update_service",
+        lambda self: None,
+    )
+    return PriceInterface(
+        {
+            "source": "timeseries",
+            "data_url": "http://evcc.local/api/tariff/grid",
+            "data_path": "rates",
+        },
+        time_frame_base=3600,
+        timezone=timezone.utc,
+    )
+
+
+def _quarter_hourly(values, count=192, start=None):
+    """Build a 15-min series repeating *values*, starting at midnight UTC today."""
+    base = start or datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    return [
+        {
+            "start": (base + timedelta(minutes=15 * i)).isoformat(),
+            "end": (base + timedelta(minutes=15 * (i + 1))).isoformat(),
+            "value": values[i % len(values)],
+        }
+        for i in range(count)
+    ]
+
+
+def _to_ct_kwh(price_eur_per_wh):
+    """Same conversion the schedule table applies (schedule.js)."""
+    return price_eur_per_wh * 100_000
+
+
+class TestEvccRatesPayload:
+    """The reported symptom: EVCC's own format rendered 34660 ct/kWh."""
+
+    def test_evcc_eur_per_kwh_lands_at_a_realistic_ct_per_kwh(self, price_interface):
+        rates = _quarter_hourly(TIBBER_PRICES_EUR_KWH)
+
+        prices = price_interface._PriceInterface__parse_price_timeseries(
+            rates, 48, value_unit="EUR/kWh"
+        )
+
+        assert prices, "EVCC's canonical payload must parse"
+        first_ct_kwh = _to_ct_kwh(prices[0])
+        assert 30.0 < first_ct_kwh < 45.0, f"got {first_ct_kwh} ct/kWh"
+
+    def test_the_reported_34660_value_no_longer_occurs(self, price_interface):
+        rates = _quarter_hourly([0.3466])
+
+        prices = price_interface._PriceInterface__parse_price_timeseries(
+            rates, 48, value_unit="EUR/kWh"
+        )
+
+        assert _to_ct_kwh(prices[0]) == pytest.approx(34.66, abs=0.01)
+
+    def test_reading_the_same_payload_as_eur_per_wh_still_warns(
+        self, price_interface, caplog
+    ):
+        rates = _quarter_hourly(TIBBER_PRICES_EUR_KWH)
+
+        with caplog.at_level("WARNING"):
+            price_interface._PriceInterface__parse_price_timeseries(
+                rates, 48, value_unit="EUR/Wh"
+            )
+
+        assert "implausible price level" in caplog.text
+
+    def test_missing_end_is_accepted(self, price_interface):
+        # EVCC supplies `end`; the Tibber HA integration does not. Neither is read.
+        rates = [
+            {key: value for key, value in entry.items() if key != "end"}
+            for entry in _quarter_hourly(TIBBER_PRICES_EUR_KWH)
+        ]
+
+        prices = price_interface._PriceInterface__parse_price_timeseries(
+            rates, 48, value_unit="EUR/kWh"
+        )
+
+        assert len(prices) == 48
+
+
+class TestHomeAssistantIntegrationPayloads:
+    """
+    Foreign field names are rejected — but the message has to say what to do.
+
+    The adaptation path is a HA template sensor (as agreed in the thread), so the
+    error names the fields that were present instead of guessing at them.
+    """
+
+    def test_tibber_hacs_attributes_rejected_with_actionable_message(
+        self, price_interface, caplog
+    ):
+        # Verbatim from #214: start_time + price_per_kwh, no end.
+        payload = [
+            {"start_time": "2026-08-23T00:00:00+02:00", "price_per_kwh": 0.3811},
+            {"start_time": "2026-08-23T00:15:00+02:00", "price_per_kwh": 0.3727},
+        ]
+
+        with caplog.at_level("ERROR"):
+            prices = price_interface._PriceInterface__parse_price_timeseries(
+                payload, 48, value_unit="EUR/kWh"
+            )
+
+        assert prices == []
+        assert "'start_time'" in caplog.text
+        assert "'price_per_kwh'" in caplog.text
+        assert "timeseries-templates" in caplog.text
+
+    def test_epex_spot_attributes_rejected_with_actionable_message(
+        self, price_interface, caplog
+    ):
+        # Verbatim from #214: start_time + end_time + price_per_kwh.
+        payload = [
+            {
+                "start_time": "2026-08-22T00:00:00+02:00",
+                "end_time": "2026-08-22T00:15:00+02:00",
+                "price_per_kwh": 0.1766,
+            },
+        ]
+
+        with caplog.at_level("ERROR"):
+            prices = price_interface._PriceInterface__parse_price_timeseries(
+                payload, 48, value_unit="EUR/kWh"
+            )
+
+        assert prices == []
+        assert "'end_time'" in caplog.text
+
+    def test_tibber_action_attributes_rejected_with_actionable_message(
+        self, price_interface, caplog
+    ):
+        # Verbatim from #214: the built-in Tibber integration's action response.
+        payload = [
+            {"start_time": "2026-08-23T00:00:00.000+02:00", "price": 0.3811},
+        ]
+
+        with caplog.at_level("ERROR"):
+            prices = price_interface._PriceInterface__parse_price_timeseries(
+                payload, 48, value_unit="EUR/kWh"
+            )
+
+        assert prices == []
+        assert "'price'" in caplog.text
+
+    def test_a_template_shaped_payload_is_accepted(self, price_interface):
+        """What the documented HA template snippet produces: start + value only."""
+        base = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        payload = [
+            {
+                "start": (base + timedelta(minutes=15 * i)).isoformat(),
+                "value": TIBBER_PRICES_EUR_KWH[i % 3],
+            }
+            for i in range(192)
+        ]
+
+        prices = price_interface._PriceInterface__parse_price_timeseries(
+            payload, 48, value_unit="EUR/kWh"
+        )
+
+        assert len(prices) == 48
+        assert 30.0 < _to_ct_kwh(prices[0]) < 45.0
+
+
+class TestUnitEscapeHatch:
+    """value_unit exists so a source that is not in EUR/kWh needs no template."""
+
+    @pytest.mark.parametrize(
+        "unit,raw",
+        [("EUR/kWh", 0.3811), ("ct/kWh", 38.11), ("EUR/Wh", 0.0003811)],
+    )
+    def test_all_units_reach_the_same_schedule_value(self, price_interface, unit, raw):
+        prices = price_interface._PriceInterface__parse_price_timeseries(
+            _quarter_hourly([raw]), 48, value_unit=unit
+        )
+
+        assert _to_ct_kwh(prices[0]) == pytest.approx(38.11, abs=0.01)
+
+
+class TestEvccInternalPathUnaffected:
+    """
+    The EVCC adapter pre-converts to EUR/Wh and passes value_unit=None.
+
+    That path must keep working untouched, otherwise fixing the generic source would
+    break the source it is modelled on.
+    """
+
+    def test_pre_normalized_entries_are_not_converted_again(self, price_interface):
+        base = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        # Already EUR/Wh, exactly as __retrieve_prices_from_evcc builds it.
+        entries = [
+            {
+                "start": (base + timedelta(minutes=15 * i)).isoformat(),
+                "end": None,
+                "value": 0.0003811,
+            }
+            for i in range(192)
+        ]
+
+        prices = price_interface._PriceInterface__parse_price_timeseries(entries, 48)
+
+        assert _to_ct_kwh(prices[0]) == pytest.approx(38.11, abs=0.01)
+
+
+class TestFullFetchPath:
+    """
+    Covers the wiring, not just the parser.
+
+    The parser tests pass value_unit explicitly; these confirm the interface reads it
+    from config (and defaults correctly) and carries it through the real fetch path.
+    """
+
+    def _rates_response(self, values):
+        base = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        rates = [
+            {
+                "start": (base + timedelta(minutes=15 * i)).isoformat(),
+                "end": (base + timedelta(minutes=15 * (i + 1))).isoformat(),
+                "value": values[i % len(values)],
+            }
+            for i in range(192)
+        ]
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"rates": rates}
+        return response, base
+
+    def test_unit_defaults_to_evcc_semantics(self, price_interface):
+        assert price_interface.value_unit == "EUR/kWh"
+
+    def test_evcc_endpoint_end_to_end(self, price_interface):
+        response, base = self._rates_response([0.3811])
+
+        with patch("requests.get", return_value=response):
+            prices = price_interface._PriceInterface__retrieve_prices_from_url(48, base)
+
+        assert len(prices) == 48
+        assert _to_ct_kwh(prices[0]) == pytest.approx(38.11, abs=0.01)
+
+    def test_configured_unit_is_honoured_end_to_end(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.interfaces.price_interface.PriceInterface._PriceInterface__start_update_service",
+            lambda self: None,
+        )
+        iface = PriceInterface(
+            {
+                "source": "timeseries",
+                "data_url": "http://ha.local/api/states/sensor.prices",
+                "data_path": "rates",
+                "value_unit": "ct/kWh",
+            },
+            time_frame_base=3600,
+            timezone=timezone.utc,
+        )
+        response, base = self._rates_response([38.11])
+
+        with patch("requests.get", return_value=response):
+            prices = iface._PriceInterface__retrieve_prices_from_url(48, base)
+
+        assert _to_ct_kwh(prices[0]) == pytest.approx(38.11, abs=0.01)
+
+
+class TestNoSilentSlotShift:
+    """
+    A malformed entry must never shift the remaining prices.
+
+    The hourly path maps entries to slots positionally, so skipping a bad entry would
+    move every later price an hour early — cheaper-looking power at the wrong time,
+    with nothing in the schedule to show for it.
+    """
+
+    def _hourly_series(self, bad_index=None, bad_value=None):
+        base = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        series = []
+        for hour in range(48):
+            value = (10 + hour) / 100.0
+            if bad_index is not None and hour == bad_index:
+                value = bad_value
+            series.append(
+                {"start": (base + timedelta(hours=hour)).isoformat(), "value": value}
+            )
+        return series
+
+    def test_clean_series_maps_one_to_one(self, price_interface):
+        prices = price_interface._PriceInterface__parse_price_timeseries(
+            self._hourly_series(), 48, value_unit="EUR/kWh"
+        )
+
+        assert [round(_to_ct_kwh(p), 1) for p in prices[4:9]] == [14.0, 15.0, 16.0, 17.0, 18.0]
+
+    def test_null_midway_rejects_instead_of_shifting(self, price_interface):
+        prices = price_interface._PriceInterface__parse_price_timeseries(
+            self._hourly_series(bad_index=5, bad_value=None), 48, value_unit="EUR/kWh"
+        )
+
+        assert prices == []
+
+    def test_rejection_leaves_the_previous_prices_in_place(self, price_interface):
+        """An unusable payload must fall back, not overwrite good data."""
+        good = self._hourly_series()
+        price_interface.last_successful_prices = (
+            price_interface._PriceInterface__parse_price_timeseries(
+                good, 48, value_unit="EUR/kWh"
+            )
+        )
+        cached = list(price_interface.last_successful_prices)
+
+        price_interface._PriceInterface__parse_price_timeseries(
+            self._hourly_series(bad_index=5, bad_value=None), 48, value_unit="EUR/kWh"
+        )
+
+        assert price_interface.last_successful_prices == cached

--- a/tests/interfaces/test_pv_timeseries_units.py
+++ b/tests/interfaces/test_pv_timeseries_units.py
@@ -1,0 +1,291 @@
+# pylint: disable=protected-access
+"""
+PV timeseries unit handling, driven by the reference sensor from discussion #214.
+
+bennobiber's Home Assistant template sensor is the sensor the thread asked EOS Connect
+to read: it emits `pv_estimate * 1000`, i.e. power in W per slot, which is what EVCC's
+solar forecast carries. Reading those values as Wh-per-slot inflated 15-minute data
+fourfold, so these tests pin the conversion and the timestamp handling around it.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytz
+
+from src.interfaces.pv_interface import PvInterface
+
+TIME_FRAME_BASE_HOURLY = 3600
+TIME_FRAME_BASE_15MIN = 900
+
+
+@pytest.fixture(autouse=True)
+def patch_thread(monkeypatch):
+    """Avoid starting the real background update thread during tests."""
+
+    class DummyThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr("threading.Thread", DummyThread)
+
+
+def make_pv_interface(source_config=None, time_frame_base=TIME_FRAME_BASE_HOURLY):
+    source_config = source_config or {"source": "timeseries"}
+    return PvInterface(
+        source_config,
+        [{"name": "test_array", "power": 4000}],
+        time_frame_base,
+        {},
+        timezone="UTC",
+    )
+
+
+def midnight_today_utc():
+    return datetime.now(pytz.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def bennobiber_payload(watts=4000.0, count=192, aware=True):
+    """
+    The shape bennobiber's template produces: start/end/value with value in W.
+
+    With ``aware=False`` the timestamps are rendered the way his template actually
+    renders them (``| timestamp_utc``), i.e. UTC wall clock with no offset.
+    """
+    base = midnight_today_utc()
+    entries = []
+    for i in range(count):
+        start = base + timedelta(minutes=15 * i)
+        end = start + timedelta(minutes=15)
+        entries.append(
+            {
+                "start": start.isoformat() if aware else start.strftime("%Y-%m-%d %H:%M:%S"),
+                "end": end.isoformat() if aware else end.strftime("%Y-%m-%d %H:%M:%S"),
+                "value": watts,
+            }
+        )
+    return entries
+
+
+class TestPowerToEnergyConversion:
+    """4000 W held across an hour is 4000 Wh — not 16000."""
+
+    def test_quarter_hourly_watts_summed_to_hourly_watt_hours(self):
+        pv = make_pv_interface()
+
+        values = pv._PvInterface__parse_pv_timeseries(
+            bennobiber_payload(watts=4000.0), 48, value_unit="W"
+        )
+
+        assert values[0] == pytest.approx(4000.0)
+
+    def test_reading_watts_as_watt_hours_is_the_fourfold_error(self):
+        """Guards the regression: the old behaviour summed four W values as Wh."""
+        pv = make_pv_interface()
+
+        values = pv._PvInterface__parse_pv_timeseries(
+            bennobiber_payload(watts=4000.0), 48, value_unit="Wh"
+        )
+
+        assert values[0] == pytest.approx(16000.0)
+
+    def test_hourly_watts_need_no_scaling(self):
+        pv = make_pv_interface()
+        base = midnight_today_utc()
+        payload = [
+            {
+                "start": (base + timedelta(hours=h)).isoformat(),
+                "value": 4000.0,
+            }
+            for h in range(48)
+        ]
+
+        values = pv._PvInterface__parse_pv_timeseries(payload, 48, value_unit="W")
+
+        assert values[0] == pytest.approx(4000.0)
+
+    def test_kilowatt_source_scaled(self):
+        pv = make_pv_interface()
+
+        values = pv._PvInterface__parse_pv_timeseries(
+            bennobiber_payload(watts=4.0), 48, value_unit="kW"
+        )
+
+        assert values[0] == pytest.approx(4000.0)
+
+    def test_unknown_unit_is_rejected_not_guessed(self, caplog):
+        pv = make_pv_interface()
+
+        with caplog.at_level("ERROR"):
+            values = pv._PvInterface__parse_pv_timeseries(
+                bennobiber_payload(), 48, value_unit="MW"
+            )
+
+        assert values == []
+        assert "unknown PV unit" in caplog.text
+
+
+class TestReferenceSensorAcceptance:
+    """
+    The acceptance criterion from the plan: bennobiber's sensor reads correctly.
+
+    Unit and shape come straight from his template; only the timestamp rendering has
+    to be corrected to carry an offset, which is what the documented snippet does.
+    """
+
+    def test_documented_snippet_shape_lands_on_the_right_slots(self):
+        pv = make_pv_interface()
+
+        values = pv._PvInterface__parse_pv_timeseries(
+            bennobiber_payload(watts=4000.0, aware=True), 48, value_unit="W"
+        )
+
+        assert len(values) == 48
+        assert all(value == pytest.approx(4000.0) for value in values)
+
+    def test_timestamp_utc_rendering_is_flagged_not_silently_shifted(self, caplog):
+        pv = make_pv_interface()
+
+        with caplog.at_level("WARNING"):
+            pv._PvInterface__parse_pv_timeseries(
+                bennobiber_payload(aware=False), 48, value_unit="W"
+            )
+
+        assert "no UTC offset" in caplog.text
+
+
+class TestEmptyWindowIsReported:
+    """48 zeros used to be indistinguishable from a genuinely dark forecast."""
+
+    def test_data_outside_the_window_warns(self, caplog):
+        pv = make_pv_interface()
+        far_off = midnight_today_utc() + timedelta(days=30)
+        payload = [
+            {
+                "start": (far_off + timedelta(hours=h)).isoformat(),
+                "value": 4000.0,
+            }
+            for h in range(48)
+        ]
+
+        with caplog.at_level("WARNING"):
+            values = pv._PvInterface__parse_pv_timeseries(payload, 48, value_unit="W")
+
+        assert values == [0.0] * 48
+        assert "None of" in caplog.text
+        assert "window starting" in caplog.text
+
+
+class TestEvccPvPathUnaffected:
+    """The EVCC adapter pre-converts to Wh and passes value_unit=None."""
+
+    def test_pre_normalized_entries_are_not_converted_again(self):
+        pv = make_pv_interface()
+        base = midnight_today_utc()
+        entries = [
+            {
+                "start": (base + timedelta(hours=h)).isoformat(),
+                "end": None,
+                "value": 4000.0,
+            }
+            for h in range(48)
+        ]
+
+        values = pv._PvInterface__parse_pv_timeseries(entries, 48)
+
+        assert values[0] == pytest.approx(4000.0)
+
+
+class TestFullFetchPath:
+    """Covers config → attribute → parser wiring, not just the parser."""
+
+    def _response(self, payload):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = payload
+        return response
+
+    def test_bennobiber_sensor_read_end_to_end(self):
+        """
+        The acceptance criterion from #214: EOS Connect reads the sensor EVCC reads.
+
+        A constant 4000 W feed is 4000 Wh per hour — 96 kWh/day. Reading the same
+        values as Wh-per-slot would report 16000 Wh/h.
+        """
+        pv = make_pv_interface(
+            {
+                "source": "timeseries",
+                "data_url": "http://homeassistant.local:8123/api/states/sensor.solcast_evcc_json",
+                "data_path": "attributes.data",
+                # value_unit omitted on purpose: must default to W
+            }
+        )
+        pv.configuration_valid = True
+        payload = {"attributes": {"data": bennobiber_payload(watts=4000.0)}}
+
+        with patch("requests.get", return_value=self._response(payload)):
+            forecast = pv._PvInterface__get_pv_forecast_timeseries(48)
+
+        assert len(forecast) == 48
+        assert forecast[0] == pytest.approx(4000.0)
+        assert sum(forecast[:24]) == pytest.approx(96_000.0)
+
+    def test_configured_unit_is_honoured_end_to_end(self):
+        pv = make_pv_interface(
+            {
+                "source": "timeseries",
+                "data_url": "http://ha.local/api/states/sensor.pv",
+                "data_path": "attributes.data",
+                "value_unit": "kW",
+            }
+        )
+        pv.configuration_valid = True
+        payload = {"attributes": {"data": bennobiber_payload(watts=4.0)}}
+
+        with patch("requests.get", return_value=self._response(payload)):
+            forecast = pv._PvInterface__get_pv_forecast_timeseries(48)
+
+        assert forecast[0] == pytest.approx(4000.0)
+
+
+class TestPvPlausibilityWarning:
+    """Unlike prices, a PV unit mistake is subtle — it needs a warning of its own."""
+
+    def test_energy_unit_on_a_power_source_warns(self, caplog):
+        pv = make_pv_interface()  # configured for a 4000 W array
+
+        with caplog.at_level("WARNING"):
+            pv._PvInterface__parse_pv_timeseries(
+                bennobiber_payload(watts=4000.0), 48, value_unit="Wh"
+            )
+
+        assert "implausible PV level" in caplog.text
+
+    def test_correct_unit_produces_no_warning(self, caplog):
+        pv = make_pv_interface()
+
+        with caplog.at_level("WARNING"):
+            pv._PvInterface__parse_pv_timeseries(
+                bennobiber_payload(watts=4000.0), 48, value_unit="W"
+            )
+
+        assert "implausible PV level" not in caplog.text
+
+    def test_active_unit_is_stated_once(self, caplog):
+        pv = make_pv_interface()
+
+        with caplog.at_level("INFO"):
+            pv._PvInterface__parse_pv_timeseries(
+                bennobiber_payload(), 48, value_unit="W"
+            )
+            first = caplog.text.count("interpreted as")
+            pv._PvInterface__parse_pv_timeseries(
+                bennobiber_payload(), 48, value_unit="W"
+            )
+
+        assert first == 1
+        assert caplog.text.count("interpreted as") == 1

--- a/tests/interfaces/test_timeseries_normalizer.py
+++ b/tests/interfaces/test_timeseries_normalizer.py
@@ -1,0 +1,423 @@
+"""Tests for the shared timeseries normalizer.
+
+Covers the contract that the price and PV interfaces both rely on: canonical field
+validation with an actionable error, derived `end`, timezone handling, and the unit
+tables. The payload shapes used here are the ones reported in discussion #214.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytz
+
+from src.interfaces.timeseries_normalizer import (
+    PRICE_UNIT_TO_EUR_PER_WH,
+    PV_UNITS,
+    TimeseriesFormatError,
+    convert_price_values,
+    convert_pv_values,
+    detect_resolution_seconds,
+    extract_json_path,
+    normalize_entries,
+    price_plausibility_message,
+    pv_plausibility_message,
+)
+
+BERLIN = pytz.timezone("Europe/Berlin")
+
+
+class TestFieldValidation:
+    """The format is fixed; the error has to make it obvious how to comply."""
+
+    def test_missing_start_names_the_available_keys(self):
+        payload = [{"start_time": "2026-08-23T00:00:00+02:00", "price_per_kwh": 0.3811}]
+
+        with pytest.raises(TimeseriesFormatError) as exc:
+            normalize_entries(payload, BERLIN)
+
+        message = str(exc.value)
+        assert "'start'" in message
+        assert "'start_time'" in message
+        assert "'price_per_kwh'" in message
+
+    def test_missing_value_names_the_available_keys(self):
+        payload = [{"start": "2026-08-23T00:00:00+02:00", "price_per_kwh": 0.3811}]
+
+        with pytest.raises(TimeseriesFormatError) as exc:
+            normalize_entries(payload, BERLIN)
+
+        assert "'value'" in str(exc.value)
+        assert "'price_per_kwh'" in str(exc.value)
+
+    def test_error_points_at_the_template_docs(self):
+        with pytest.raises(TimeseriesFormatError) as exc:
+            normalize_entries([{"foo": 1}], BERLIN)
+
+        assert "timeseries-templates" in str(exc.value)
+
+    def test_non_list_payload_rejected(self):
+        with pytest.raises(TimeseriesFormatError):
+            normalize_entries({"start": "x", "value": 1}, BERLIN)
+
+    def test_empty_payload_rejected(self):
+        with pytest.raises(TimeseriesFormatError):
+            normalize_entries([], BERLIN)
+
+    def test_one_unparseable_entry_rejects_the_payload(self):
+        """
+        Dropping the bad entry instead would corrupt the result silently.
+
+        The hourly price path maps the normalized list to slots by position, so a
+        single missing entry shifts every later price an hour early — and in the
+        direction that makes grid power look cheaper than it is. Rejecting lets the
+        caller fall back to its cache instead.
+        """
+        payload = [
+            {"start": "2026-08-23T00:00:00+02:00", "value": 0.30},
+            {"start": "not-a-timestamp", "value": 0.31},
+            {"start": "2026-08-23T01:00:00+02:00", "value": 0.32},
+        ]
+
+        with pytest.raises(TimeseriesFormatError) as exc:
+            normalize_entries(payload, BERLIN)
+
+        assert "entry 1" in str(exc.value)
+
+    def test_null_value_rejects_the_payload(self):
+        payload = [
+            {"start": "2026-08-23T00:00:00+02:00", "value": 0.30},
+            {"start": "2026-08-23T01:00:00+02:00", "value": None},
+        ]
+
+        with pytest.raises(TimeseriesFormatError) as exc:
+            normalize_entries(payload, BERLIN)
+
+        assert "entry 1" in str(exc.value)
+        assert "non-numeric" in str(exc.value)
+
+    def test_entry_missing_a_field_midway_rejects_the_payload(self):
+        payload = [
+            {"start": "2026-08-23T00:00:00+02:00", "value": 0.30},
+            {"start": "2026-08-23T01:00:00+02:00"},
+        ]
+
+        with pytest.raises(TimeseriesFormatError) as exc:
+            normalize_entries(payload, BERLIN)
+
+        assert "entry 1" in str(exc.value)
+
+    def test_all_entries_unusable_is_fatal(self):
+        payload = [
+            {"start": "2026-08-23T00:00:00+02:00", "value": "abc"},
+            {"start": "2026-08-23T01:00:00+02:00", "value": "def"},
+        ]
+
+        with pytest.raises(TimeseriesFormatError):
+            normalize_entries(payload, BERLIN)
+
+
+class TestEndDerivation:
+    """`end` is part of the documented format but never read — absence must not reject."""
+
+    def test_end_derived_from_next_start(self):
+        payload = [
+            {"start": "2026-08-23T00:00:00+02:00", "value": 0.3811},
+            {"start": "2026-08-23T00:15:00+02:00", "value": 0.3727},
+        ]
+
+        entries = normalize_entries(payload, BERLIN)
+
+        assert entries[0]["end"] == entries[1]["start"]
+
+    def test_last_end_reuses_the_preceding_delta(self):
+        payload = [
+            {"start": "2026-08-23T00:00:00+02:00", "value": 0.3811},
+            {"start": "2026-08-23T00:15:00+02:00", "value": 0.3727},
+        ]
+
+        entries = normalize_entries(payload, BERLIN)
+
+        assert entries[-1]["end"] - entries[-1]["start"] == timedelta(minutes=15)
+
+    def test_single_entry_falls_back_to_one_hour(self):
+        entries = normalize_entries(
+            [{"start": "2026-08-23T00:00:00+02:00", "value": 0.3811}], BERLIN
+        )
+
+        assert entries[0]["end"] - entries[0]["start"] == timedelta(hours=1)
+
+    def test_supplied_end_is_ignored_in_favour_of_the_derived_one(self):
+        # EPEX supplies end_time, EVCC supplies end; neither is read for any
+        # calculation, so the derived value is what the rest of the code sees.
+        payload = [
+            {"start": "2026-08-23T00:00:00+02:00", "end": "bogus", "value": 0.1766},
+            {"start": "2026-08-23T00:15:00+02:00", "end": "bogus", "value": 0.1716},
+        ]
+
+        entries = normalize_entries(payload, BERLIN)
+
+        assert entries[0]["end"] == entries[1]["start"]
+
+    def test_entries_are_sorted_by_start(self):
+        payload = [
+            {"start": "2026-08-23T01:00:00+02:00", "value": 2.0},
+            {"start": "2026-08-23T00:00:00+02:00", "value": 1.0},
+        ]
+
+        entries = normalize_entries(payload, BERLIN)
+
+        assert [entry["value"] for entry in entries] == [1.0, 2.0]
+
+
+class TestTimestampHandling:
+    def test_offset_timestamps_preserved_as_instants(self):
+        entries = normalize_entries(
+            [{"start": "2026-08-23T00:00:00+02:00", "value": 1.0}], BERLIN
+        )
+
+        assert entries[0]["start"].utcoffset() == timedelta(hours=2)
+
+    def test_zulu_timestamps_accepted(self):
+        entries = normalize_entries(
+            [{"start": "2026-08-23T00:00:00Z", "value": 1.0}], BERLIN
+        )
+
+        assert entries[0]["start"] == datetime(2026, 8, 23, 0, 0, tzinfo=timezone.utc)
+
+    def test_unix_timestamps_accepted(self):
+        entries = normalize_entries([{"start": 1_756_000_000, "value": 1.0}], BERLIN)
+
+        assert entries[0]["start"].tzinfo is not None
+
+    def test_naive_timestamp_localized_and_warned(self, caplog):
+        # This is bennobiber's template from #214: `| timestamp_utc` renders UTC wall
+        # clock with no offset, which would otherwise silently shift every slot.
+        with caplog.at_level("WARNING"):
+            entries = normalize_entries(
+                [{"start": "2026-08-23 12:00:00", "value": 1.0}], BERLIN
+            )
+
+        assert entries[0]["start"].tzinfo is not None
+        assert "no UTC offset" in caplog.text
+        assert "isoformat" in caplog.text
+
+    def test_plain_tzinfo_without_localize_supported(self):
+        # Tests construct interfaces with datetime.timezone.utc, which has no
+        # pytz-style localize().
+        entries = normalize_entries(
+            [{"start": "2026-08-23 12:00:00", "value": 1.0}], timezone.utc
+        )
+
+        assert entries[0]["start"].tzinfo is not None
+
+    def test_boolean_start_rejected(self):
+        with pytest.raises(TimeseriesFormatError):
+            normalize_entries([{"start": True, "value": 1.0}] * 2, BERLIN)
+
+
+class TestResolutionDetection:
+    def test_detects_quarter_hourly(self):
+        entries = normalize_entries(
+            [
+                {"start": "2026-08-23T00:00:00+02:00", "value": 1.0},
+                {"start": "2026-08-23T00:15:00+02:00", "value": 1.0},
+            ],
+            BERLIN,
+        )
+
+        assert detect_resolution_seconds(entries) == 900
+
+    def test_detects_hourly(self):
+        entries = normalize_entries(
+            [
+                {"start": "2026-08-23T00:00:00+02:00", "value": 1.0},
+                {"start": "2026-08-23T01:00:00+02:00", "value": 1.0},
+            ],
+            BERLIN,
+        )
+
+        assert detect_resolution_seconds(entries) == 3600
+
+    def test_unsupported_spacing_returns_none(self):
+        entries = normalize_entries(
+            [
+                {"start": "2026-08-23T00:00:00+02:00", "value": 1.0},
+                {"start": "2026-08-23T00:05:00+02:00", "value": 1.0},
+            ],
+            BERLIN,
+        )
+
+        assert detect_resolution_seconds(entries) is None
+
+    def test_single_entry_returns_none(self):
+        entries = normalize_entries(
+            [{"start": "2026-08-23T00:00:00+02:00", "value": 1.0}], BERLIN
+        )
+
+        assert detect_resolution_seconds(entries) is None
+
+
+class TestPriceUnitConversion:
+    """EUR/kWh is the canonical unit because that is what EVCC's rates carry."""
+
+    @pytest.mark.parametrize(
+        "unit,raw,expected_eur_per_wh",
+        [
+            ("EUR/kWh", 0.3811, 0.0003811),
+            ("ct/kWh", 38.11, 0.0003811),
+            ("EUR/Wh", 0.0003811, 0.0003811),
+        ],
+    )
+    def test_units_converge_on_the_same_internal_value(
+        self, unit, raw, expected_eur_per_wh
+    ):
+        entries = [{"start": None, "end": None, "value": raw}]
+
+        convert_price_values(entries, unit)
+
+        assert entries[0]["value"] == pytest.approx(expected_eur_per_wh)
+
+    def test_every_documented_unit_is_supported(self):
+        assert set(PRICE_UNIT_TO_EUR_PER_WH) == {"EUR/kWh", "ct/kWh", "EUR/Wh"}
+
+    def test_unknown_unit_rejected(self):
+        with pytest.raises(TimeseriesFormatError):
+            convert_price_values([{"value": 1.0}], "USD/kWh")
+
+    def test_negative_prices_keep_their_sign(self):
+        entries = [{"value": -0.05}]
+
+        convert_price_values(entries, "EUR/kWh")
+
+        assert entries[0]["value"] < 0
+
+
+class TestPvUnitConversion:
+    """W is canonical because that is what EVCC's solar forecast carries."""
+
+    def test_watts_integrated_over_a_quarter_hour(self):
+        entries = [{"value": 4000.0}]
+
+        convert_pv_values(entries, "W", 900)
+
+        assert entries[0]["value"] == pytest.approx(1000.0)
+
+    def test_watts_over_a_full_hour_are_watt_hours(self):
+        entries = [{"value": 4000.0}]
+
+        convert_pv_values(entries, "W", 3600)
+
+        assert entries[0]["value"] == pytest.approx(4000.0)
+
+    def test_kilowatts_scaled_and_integrated(self):
+        entries = [{"value": 4.0}]
+
+        convert_pv_values(entries, "kW", 900)
+
+        assert entries[0]["value"] == pytest.approx(1000.0)
+
+    def test_energy_units_pass_through_regardless_of_slot_length(self):
+        entries = [{"value": 1000.0}]
+
+        convert_pv_values(entries, "Wh", 900)
+
+        assert entries[0]["value"] == pytest.approx(1000.0)
+
+    def test_kilowatt_hours_scaled(self):
+        entries = [{"value": 1.0}]
+
+        convert_pv_values(entries, "kWh", 900)
+
+        assert entries[0]["value"] == pytest.approx(1000.0)
+
+    def test_every_documented_unit_is_supported(self):
+        assert set(PV_UNITS) == {"W", "kW", "Wh", "kWh"}
+
+    def test_unknown_unit_rejected(self):
+        with pytest.raises(TimeseriesFormatError):
+            convert_pv_values([{"value": 1.0}], "MW", 900)
+
+
+class TestPricePlausibility:
+    def test_realistic_prices_produce_no_warning(self):
+        values = [0.0003811, 0.0003727, 0.0003668]
+
+        assert price_plausibility_message(values, "EUR/kWh") is None
+
+    def test_thousandfold_too_high_is_flagged(self):
+        # Exactly Tobias' case: EVCC's EUR/kWh read as EUR/Wh.
+        values = [0.3811, 0.3727, 0.3668]
+
+        message = price_plausibility_message(values, "EUR/Wh")
+
+        assert message is not None
+        assert "too high" in message
+
+    def test_thousandfold_too_low_is_flagged(self):
+        values = [0.0000003811, 0.0000003727]
+
+        message = price_plausibility_message(values, "EUR/Wh")
+
+        assert message is not None
+        assert "too low" in message
+
+    def test_a_few_negative_hours_do_not_trip_the_check(self):
+        values = [-0.0001, 0.0] + [0.0003] * 20
+
+        assert price_plausibility_message(values, "EUR/kWh") is None
+
+    def test_empty_input_is_not_a_warning(self):
+        assert price_plausibility_message([], "EUR/kWh") is None
+
+
+class TestExtractJsonPath:
+    """Shared by both interfaces and the probe, so the probe cannot disagree."""
+
+    def test_nested_attribute_path(self):
+        payload = {"attributes": {"data": [1, 2]}}
+
+        assert extract_json_path(payload, "attributes.data") == [1, 2]
+
+    def test_top_level_path(self):
+        assert extract_json_path({"rates": [1]}, "rates") == [1]
+
+    def test_array_index_notation(self):
+        payload = {"prices": [{"data": [7]}]}
+
+        assert extract_json_path(payload, "prices[0].data") == [7]
+
+    def test_missing_path_returns_none(self):
+        assert extract_json_path({"a": 1}, "b.c") is None
+
+
+class TestPvPlausibility:
+    """Catches the power/energy mix-up, which is only a factor of four."""
+
+    def test_matching_installation_is_silent(self):
+        # 4000 W across 15 min = 1000 Wh per slot on a 4 kW array.
+        assert (
+            pv_plausibility_message([1000.0] * 4, "W", 900, 4000)
+            is None
+        )
+
+    def test_peak_beyond_installed_capacity_is_flagged(self):
+        # Power read as energy: 4000 "Wh" per 15-min slot implies 16 kW.
+        message = pv_plausibility_message([4000.0] * 4, "Wh", 900, 4000)
+
+        assert message is not None
+        assert "implausible PV level" in message
+
+    def test_message_names_the_configured_unit(self):
+        message = pv_plausibility_message([4000.0], "Wh", 900, 4000)
+
+        assert "'Wh'" in message
+
+    def test_modest_overshoot_is_tolerated(self):
+        # Optimistic forecasts and oversized arrays must not produce noise.
+        assert pv_plausibility_message([1100.0], "W", 900, 4000) is None
+
+    def test_unknown_installed_power_disables_the_check(self):
+        assert pv_plausibility_message([99999.0], "Wh", 900, 0) is None
+
+    def test_empty_values_are_not_a_warning(self):
+        assert pv_plausibility_message([], "W", 900, 4000) is None


### PR DESCRIPTION
The unified timeseries source was documented as accepting EVCC's {start, end, value} payload but expected the units EOS Connect uses internally: EUR/Wh for prices and Wh-per-slot for PV. No real source publishes either. Pointing the source at EVCC's own /api/tariff/grid therefore rendered 34660 ct/kWh, and Home Assistant sensors were rejected over a mandatory `end` field that is never read.

Prices are now read as EUR/kWh and PV as W, matching what EVCC and the common Home Assistant integrations deliver, with value_unit as an escape hatch for anything else. `end` is derived from the following entry. Parsing stays strict otherwise: one malformed entry rejects the payload, because dropping it would shift every later hourly price a slot early with nothing in the UI to show for it.

Foreign attribute names remain unsupported by design — the adaptation path is a Home Assistant template sensor, and the docs now carry ready-made snippets for the sources reported in the discussion. To make that strictness workable, the documented but missing POST /api/config/test-timeseries endpoint now exists and reports the first slots converted into the unit the schedule shows, so a wrong unit is visible before saving rather than hours later.

BREAKING CHANGE: existing timeseries configurations inherit the new default unit and change meaning. Set value_unit to EUR/Wh resp. Wh to restore the previous behaviour.

Fixes: #214