### PR TITLE
feat(pv): support forecast.solar API keys

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -246,7 +246,7 @@ Use `depends_on` field attribute to enforce cross-field dependencies:
 
 - **`inverter.type` → `evcc.url`**: If user selects "evcc" as inverter controller but `evcc.url` is empty or default, the option is greyed out with tooltip "Configure EVCC URL first". API validation returns `unmet_dependencies` error and prevents save.
 - **`pv_forecast_source.source` → `evcc.url`**: If user selects "evcc" as PV source but `evcc.url` is empty or default, the option is greyed out. API validation blocks save with "EVCC selected as PV source but EVCC URL not configured".
-- `pv_forecast_source.api_key`: Only visible if source is "solcast" or "victron"
+- `pv_forecast_source.api_key`: Only visible if source is "solcast", "victron" or "forecast_solar". Required for the first two; optional for Forecast.Solar, which works without a key on its public tier (12 requests/hour per IP). The field's `description_map` supplies the per-source wording.
 - `mqtt.broker`: Only visible when `mqtt.enabled` is true
 
 **Dependency validation across UI layers:**

--- a/docs/assets/data/config_schema.json
+++ b/docs/assets/data/config_schema.json
@@ -1514,18 +1514,26 @@
       "default": "",
       "section": "pv_forecast_source",
       "level": "getting_started",
-      "description": "API key for Solcast or Victron (required when using those providers)",
+      "description": "API key for the forecast provider",
       "labels": [],
       "help_url": "configuration.html#pv-forecast",
       "validation": {},
       "depends_on": {
         "pv_forecast_source.source": [
           "solcast",
-          "victron"
+          "victron",
+          "forecast_solar"
         ]
       },
       "hot_reload": true,
-      "display_group": "Provider"
+      "display_group": "Provider",
+      "description_map": {
+        "pv_forecast_source.source": {
+          "solcast": "Solcast API key (required)",
+          "victron": "Victron VRM API token (required)",
+          "forecast_solar": "Forecast.Solar API key (optional) - the public tier allows 12 requests/hour per IP address; a Personal or Professional key raises that quota and meters it against the key instead"
+        }
+      }
     },
     {
       "key": "pv_forecast_source.resource_id",

--- a/docs/user-guide/configuration.html
+++ b/docs/user-guide/configuration.html
@@ -3565,8 +3565,11 @@ price:
                                 the public tier applies: <strong>12 requests per hour, counted per IP address</strong>.
                                 With a key the quota is counted against the key instead, and Personal
                                 (2 planes) or Professional (3&ndash;4 planes) accounts allow more.
-                                The key is sent as the first path segment of the request URL and is
-                                redacted from the debug log.
+                                The key is sent as the first path segment of the request URL.
+                                Neither the key nor your coordinates appear in the debug log &mdash;
+                                it shows <code>.../***/estimate/&lt;lat&gt;/&lt;lon&gt;/...</code>, so a log
+                                excerpt attached to a bug report carries neither your credential nor
+                                your address.
                             </td>
                         </tr>
                     </table>

--- a/docs/user-guide/configuration.html
+++ b/docs/user-guide/configuration.html
@@ -3416,7 +3416,7 @@ price:
                                 <code>akkudoktor</code> - Akkudoktor API<br>
                                 <code>openmeteo</code> - Open-Meteo<br>
                                 <code>openmeteo_local</code> - Open-Meteo with local shading<br>
-                                <code>forecast_solar</code> - Forecast.Solar<br>
+                                <code>forecast_solar</code> - Forecast.Solar (see the rate-limit note below)<br>
                                 <code>evcc</code> - EVCC integration<br>
                                 <code>solcast</code> - Solcast<br>
                                 <code>victron</code> - Victron VRM API<br>
@@ -3431,6 +3431,22 @@ price:
                             <td><code>default</code></td>
                         </tr>
                     </table>
+
+                    <div class="alert alert-warning" style="margin-top: 1rem;">
+                        <strong><i class="fas fa-exclamation-triangle"></i> Forecast.Solar request
+                        budget:</strong> Forecast.Solar meters requests per <em>zone</em> &mdash; your IP
+                        address, or your API key once one is configured &mdash; and the public tier allows
+                        <strong>12 requests per hour</strong>. EOS Connect spends one request per PV
+                        installation per update cycle, so the update interval scales with the number of
+                        installations: 15 minutes for one, 30 for two, 45 for three, and so on. That holds
+                        total traffic at four requests per hour whatever your array looks like.
+                        <br><br>
+                        If the API does return <code>429 Too Many Requests</code>, EOS Connect stops calling
+                        until the retry time it reports has passed, and serves the cached forecast meanwhile.
+                        Retrying sooner only restarts the block, which is why a rate-limited setup used to
+                        appear permanently stuck. Set <code>pv_forecast_source.api_key</code> below to raise
+                        the quota.
+                    </div>
 
                     <div class="alert alert-info" style="margin-top: 1rem;">
                         <strong><i class="fas fa-info-circle"></i> PV Installations Configuration:</strong> Only
@@ -3529,11 +3545,13 @@ price:
                         </tr>
                         <tr>
                             <th>Description</th>
-                            <td>API key for authentication (used by Solcast and Victron VRM)</td>
+                            <td>API key for authentication (used by Solcast, Victron VRM and Forecast.Solar)</td>
                         </tr>
                         <tr>
                             <th>Required</th>
-                            <td>Yes, when source is <code>solcast</code> or <code>victron</code></td>
+                            <td>Yes, when source is <code>solcast</code> or <code>victron</code>.
+                                Optional for <code>forecast_solar</code> &mdash; that source works without
+                                a key on the public tier.</td>
                         </tr>
                         <tr>
                             <th>Notes</th>
@@ -3541,7 +3559,14 @@ price:
                                 <strong>Solcast:</strong> Obtain from <a href="https://solcast.com/"
                                     target="_blank">solcast.com</a>. Free accounts limited to 10 calls/day.<br>
                                 <strong>Victron:</strong> Generate in VRM portal (Preferences → API tokens). Requires
-                                "Dynamic ESS" configured in VRM portal.
+                                "Dynamic ESS" configured in VRM portal.<br>
+                                <strong>Forecast.Solar:</strong> Optional. Obtain from
+                                <a href="https://forecast.solar/" target="_blank">forecast.solar</a>. Without a key
+                                the public tier applies: <strong>12 requests per hour, counted per IP address</strong>.
+                                With a key the quota is counted against the key instead, and Personal
+                                (2 planes) or Professional (3&ndash;4 planes) accounts allow more.
+                                The key is sent as the first path segment of the request URL and is
+                                redacted from the debug log.
                             </td>
                         </tr>
                     </table>

--- a/src/config_web/schema.py
+++ b/src/config_web/schema.py
@@ -1234,10 +1234,26 @@ _ALL_FIELDS: list[FieldDef] = [
         default="",
         section="pv_forecast_source",
         level="getting_started",
-        description="API key for Solcast or Victron (required when using those providers)",
+        description="API key for the forecast provider",
         hot_reload=True,
         help_url="configuration.html#pv-forecast",
-        depends_on={"pv_forecast_source.source": ["solcast", "victron"]},
+        # Forecast.Solar is the odd one out: it works without a key on the public tier,
+        # so the key is offered but never required.  Solcast and Victron cannot fetch
+        # anything without one.
+        description_map={
+            "pv_forecast_source.source": {
+                "solcast": "Solcast API key (required)",
+                "victron": "Victron VRM API token (required)",
+                "forecast_solar": (
+                    "Forecast.Solar API key (optional) - the public tier allows 12 "
+                    "requests/hour per IP address; a Personal or Professional key "
+                    "raises that quota and meters it against the key instead"
+                ),
+            }
+        },
+        depends_on={
+            "pv_forecast_source.source": ["solcast", "victron", "forecast_solar"]
+        },
         display_group="Provider",
     ),
     FieldDef(

--- a/src/interfaces/pv_interface.py
+++ b/src/interfaces/pv_interface.py
@@ -2182,12 +2182,18 @@ class PvInterface:
 
     def __forecast_solar_request_path(self, pv_config_entry):
         """
-        Build the keyless part of a Forecast.Solar estimate URL.
+        Build the keyless part of a Forecast.Solar estimate URL, and a loggable twin.
 
-        Deliberately knows nothing about the API key.  The key is the first path segment
-        rather than a header or query parameter (https://doc.forecast.solar/api:estimate),
-        so the caller prefixes it - and can log this suffix freely, because no credential
-        has ever been near it.
+        Two things must never reach the log here.  The API key, because it is the first
+        path segment rather than a header or query parameter
+        (https://doc.forecast.solar/api:estimate) - that one the caller prefixes, so it
+        is not this function's problem.  And the coordinates, which are the user's home
+        address to within metres: the bug reporter offers to paste recent log lines into
+        a public GitHub issue, so a debug line carrying them is a real disclosure.
+
+        Returns ``(path, loggable_path)``.  The second is built from the same parameters
+        minus latitude and longitude, so everything that helps diagnose a malformed
+        request survives and nothing private does.
         """
         latitude = pv_config_entry["lat"]
         longitude = pv_config_entry["lon"]
@@ -2219,9 +2225,13 @@ class PvInterface:
                 horizon_forecast_solar_api * (24 // len(horizon_forecast_solar_api) + 1)
             )[:24]
 
-        return (
-            f"estimate/{latitude}/{longitude}/{tilt}/{azimuth}/{installed_power_watt}"
+        parameters = (
+            f"{tilt}/{azimuth}/{installed_power_watt}"
             f"?horizon={','.join(map(str, horizon_forecast_solar_api))}"
+        )
+        return (
+            f"estimate/{latitude}/{longitude}/{parameters}",
+            f"estimate/<lat>/<lon>/{parameters}",
         )
 
     def __forecast_solar_retry_after_seconds(self, response):
@@ -2311,22 +2321,22 @@ class PvInterface:
             )
             return self.__forecast_solar_hold_response(pv_config_entry, hold_remaining)
 
-        # The key is a path segment, so the request URL is a credential and must not be
-        # logged.  Build the two strings from the same keyless suffix rather than
-        # deriving the log line from the URL: nothing the key touches reaches the log,
-        # which is also what stops static analysis reading this as a leak.
-        request_path = self.__forecast_solar_request_path(pv_config_entry)
+        # The request URL carries both the API key (first path segment) and the user's
+        # coordinates, so it is never logged as-is.  ``loggable_path`` is built without
+        # the coordinates, and the key is masked here; the two strings are kept separate
+        # all the way to the sink so nothing private has a route into the log.
+        request_path, loggable_path = self.__forecast_solar_request_path(pv_config_entry)
         api_key = str(self.config_source.get("api_key", "") or "").strip()
         if api_key:
             url = f"https://api.forecast.solar/{api_key}/{request_path}"
-            loggable_url = f"https://api.forecast.solar/***/{request_path}"
+            loggable_url = f"https://api.forecast.solar/***/{loggable_path}"
         else:
             url = f"https://api.forecast.solar/{request_path}"
-            # Built again rather than aliased to ``url``: the two must never share a
-            # value, or the branch above leaks the key into the log by association.
-            loggable_url = f"https://api.forecast.solar/{request_path}"
+            loggable_url = f"https://api.forecast.solar/{loggable_path}"
         logger.debug(
-            "[PV-IF] Fetching PV forecast from Forecast.Solar API: %s", loggable_url
+            "[PV-IF] Fetching PV forecast from Forecast.Solar API for '%s': %s",
+            pv_config_entry.get("name", "unnamed"),
+            loggable_url,
         )
 
         def request_func():

--- a/src/interfaces/pv_interface.py
+++ b/src/interfaces/pv_interface.py
@@ -61,6 +61,30 @@ TEMP_REFRESH_INTERVAL_S = 3600
 TEMP_MAX_RETRIES = 2
 TEMP_RETRY_DELAY_S = 2
 
+# Forecast.Solar meters requests per "zone" - the caller's IP address, or the API key
+# once one is configured - and the public tier allows 12 per hour.  Their own guidance
+# is blunt about the failure mode: "If you ignore the 'retry at' timestamp and call over
+# and over again, you get an infinite 429 loop."  These bound the pause we take after a
+# 429 when the response does not tell us how long to wait, or tells us something absurd.
+FORECAST_SOLAR_DEFAULT_HOLD_S = 3600  # the public tier's own period
+FORECAST_SOLAR_MIN_HOLD_S = 60
+FORECAST_SOLAR_MAX_HOLD_S = 2 * 3600
+
+
+class _ForecastSolarRateLimit(Exception):
+    """
+    A 429 from Forecast.Solar, raised so it escapes ``_retry_request`` untouched.
+
+    Deliberately not a ``RequestException``: that is one of the families
+    ``_retry_request`` catches and retries three times, which is precisely how a single
+    rate-limited cycle used to turn into three more requests against a quota that was
+    already exhausted.  A plain ``Exception`` propagates on the first attempt.
+    """
+
+    def __init__(self, hold_seconds):
+        super().__init__(f"rate limited, holding off for {hold_seconds}s")
+        self.hold_seconds = hold_seconds
+
 
 from .timeseries_normalizer import (
     TEMPLATE_DOCS_ANCHOR,
@@ -162,6 +186,9 @@ class PvInterface:
         self.max_failures = 24  # Max consecutive failures before using defaults
         # Monotonic timestamp of the last successful temperature fetch (None = never).
         self._last_temp_fetch = None
+        # When Forecast.Solar last said "429, come back later" - no request is made
+        # before it passes.  See ``_ForecastSolarRateLimit``.
+        self._forecast_solar_hold_until = None
 
         self._update_thread = None
         self._stop_event = threading.Event()
@@ -227,6 +254,19 @@ class PvInterface:
         elif source == "victron":
             self.update_interval = 15 * 60
             logger.info("[PV-IF] Using standard update interval for Victron: 15 minutes")
+        elif source == "forecast_solar":
+            # One request per plane per cycle, against a public tier that allows 12 per
+            # hour for the whole zone.  A flat 15 minutes meant three planes sat exactly
+            # on the ceiling before a single retry, so scale with the plane count and
+            # total traffic stays at four requests an hour whatever the array looks like.
+            installations = max(1, len(self.config) if self.config else 1)
+            self.update_interval = 15 * 60 * installations
+            logger.info(
+                "[PV-IF] Using update interval for Forecast.Solar: %d minutes"
+                " (%d installation(s), 4 requests/hour total)",
+                self.update_interval // 60,
+                installations,
+            )
         else:
             self.update_interval = 15 * 60
 
@@ -284,6 +324,10 @@ class PvInterface:
             self.consecutive_failures = 0
             self.consecutive_temp_failures = 0
             self._last_temp_fetch = None
+            # A reload is a deliberate user action, and adding or removing the API key
+            # moves us to a different quota zone, so an old hold no longer describes
+            # anything real.  It re-arms on the next 429 if we are still blocked.
+            self._forecast_solar_hold_until = None
 
             try:
                 self.__configure_update_interval()
@@ -2136,9 +2180,14 @@ class PvInterface:
                 "openmeteo_lib",
             )
 
-    def __get_pv_forecast_forecast_solar_api(self, pv_config_entry):
+    def __forecast_solar_url(self, pv_config_entry):
         """
-        Fetches PV forecast from Forecast.Solar API.
+        Build the Forecast.Solar estimate URL, plus a copy safe to log.
+
+        The API key is the first path segment rather than a header or query parameter
+        (https://doc.forecast.solar/api:estimate), and leaving it out selects the public
+        tier.  That also means logging the URL verbatim would write a credential into
+        the log file on every cycle, hence the second, redacted return value.
         """
         latitude = pv_config_entry["lat"]
         longitude = pv_config_entry["lon"]
@@ -2170,27 +2219,156 @@ class PvInterface:
                 horizon_forecast_solar_api * (24 // len(horizon_forecast_solar_api) + 1)
             )[:24]
 
-        url = (
-            f"https://api.forecast.solar/estimate/"
-            f"{latitude}/{longitude}/{tilt}/{azimuth}/{installed_power_watt}"
+        api_key = str(self.config_source.get("api_key", "") or "").strip()
+        path = (
+            f"estimate/{latitude}/{longitude}/{tilt}/{azimuth}/{installed_power_watt}"
             f"?horizon={','.join(map(str, horizon_forecast_solar_api))}"
         )
-        logger.debug("[PV-IF] Fetching PV forecast from Forecast.Solar API: %s", url)
+        base = "https://api.forecast.solar/"
+        return (
+            f"{base}{api_key + '/' if api_key else ''}{path}",
+            f"{base}{'***/' if api_key else ''}{path}",
+        )
+
+    def __forecast_solar_retry_after_seconds(self, response):
+        """
+        How long to stay off Forecast.Solar after the 429 it just returned.
+
+        Reads the most specific answer the response offers and falls back to the public
+        tier's own period.  Everything is defensive: a malformed 429 body must not raise
+        out of the error path, because the whole point is to stop calling.
+        """
+        candidates = []
+
+        headers = getattr(response, "headers", None) or {}
+        for header in ("Retry-After", "X-Ratelimit-Reset"):
+            try:
+                candidates.append(int(float(headers.get(header))))
+            except (TypeError, ValueError):
+                pass
+
+        try:
+            ratelimit = response.json().get("message", {}).get("ratelimit", {})
+        except (ValueError, TypeError, AttributeError):
+            ratelimit = {}
+
+        retry_at = ratelimit.get("retry-at") if isinstance(ratelimit, dict) else None
+        if retry_at:
+            try:
+                target = datetime.fromisoformat(str(retry_at).replace("Z", "+00:00"))
+                now = datetime.now(target.tzinfo) if target.tzinfo else datetime.now()
+                candidates.append(int((target - now).total_seconds()))
+            except (ValueError, TypeError):
+                pass
+
+        if isinstance(ratelimit, dict):
+            try:
+                candidates.append(int(float(ratelimit.get("reset"))))
+            except (TypeError, ValueError):
+                pass
+
+        usable = [c for c in candidates if c > 0]
+        hold = usable[0] if usable else FORECAST_SOLAR_DEFAULT_HOLD_S
+        return max(FORECAST_SOLAR_MIN_HOLD_S, min(FORECAST_SOLAR_MAX_HOLD_S, hold))
+
+    def __forecast_solar_hold_remaining(self):
+        """Seconds left on an active Forecast.Solar rate-limit hold; 0 when clear."""
+        if self._forecast_solar_hold_until is None:
+            return 0
+        remaining = (self._forecast_solar_hold_until - datetime.now()).total_seconds()
+        if remaining <= 0:
+            self._forecast_solar_hold_until = None
+            return 0
+        return int(remaining)
+
+    def __forecast_solar_hold_response(self, pv_config_entry, hold_seconds):
+        """
+        Report the rate-limit hold and hand back the cached forecast.
+
+        Deliberately does not touch ``consecutive_failures``: waiting out a quota we
+        were told to wait out is not a failed fetch, and counting it as one would burn
+        through ``max_failures`` and discard the very cache the hold exists to protect.
+        """
+        self.pv_forcast_request_error.update(
+            {
+                "error": "rate_limit",
+                "timestamp": datetime.now().isoformat(),
+                "message": (
+                    "Forecast.Solar rate limit reached - no further requests for "
+                    f"{hold_seconds}s. The public tier allows 12 requests/hour per IP; "
+                    "an API key (Settings -> PV Source) raises that quota."
+                ),
+                "config_entry": pv_config_entry,
+                "source": "forecast_solar",
+            }
+        )
+        return list(self.last_successful_pv_forecast)
+
+    def __get_pv_forecast_forecast_solar_api(self, pv_config_entry):
+        """
+        Fetches PV forecast from Forecast.Solar API.
+        """
+        hold_remaining = self.__forecast_solar_hold_remaining()
+        if hold_remaining > 0:
+            logger.warning(
+                "[PV-IF] Forecast.Solar rate limit still active - skipping this request"
+                " for another %d s. Calling again earlier only renews the block.",
+                hold_remaining,
+            )
+            return self.__forecast_solar_hold_response(pv_config_entry, hold_remaining)
+
+        url, redacted_url = self.__forecast_solar_url(pv_config_entry)
+        logger.debug(
+            "[PV-IF] Fetching PV forecast from Forecast.Solar API: %s", redacted_url
+        )
 
         def request_func():
             response = requests.get(url, timeout=5)
+            if response.status_code == 429:
+                raise _ForecastSolarRateLimit(
+                    self.__forecast_solar_retry_after_seconds(response)
+                )
+            if response.status_code in (401, 403):
+                raise requests.exceptions.RequestException("auth_error")
             response.raise_for_status()
             return response
 
         def error_handler(error_type, exception):
+            if str(exception) == "auth_error":
+                message = (
+                    "Forecast.Solar rejected the API key - check api_key in"
+                    " Settings -> PV Source, or clear it to use the public tier"
+                )
+            else:
+                message = f"Forecast.Solar API error: {exception}"
             return self._handle_interface_error(
                 error_type,
-                f"Forecast.Solar API error: {exception}",
+                message,
                 pv_config_entry,
                 "forecast_solar",
             )
 
-        response = self._retry_request(request_func, error_handler)
+        try:
+            response = self._retry_request(request_func, error_handler)
+        except _ForecastSolarRateLimit as exc:
+            self._forecast_solar_hold_until = datetime.now() + timedelta(
+                seconds=exc.hold_seconds
+            )
+            logger.error(
+                "[PV-IF] Forecast.Solar returned 429 - pausing requests for %d s.",
+                exc.hold_seconds,
+            )
+            # Once, as the hold is armed.  The skip path below is silent about the
+            # background because it runs every cycle until the hold expires.
+            self._log_error_diagnostics("rate_limit", "forecast_solar")
+            return self.__forecast_solar_hold_response(pv_config_entry, exc.hold_seconds)
+
+        # _retry_request hands back the error handler's fallback - a forecast list -
+        # when every attempt failed.  Without this the list fell through to .json()
+        # below, raised AttributeError, and ran the error handler a second time,
+        # counting one failed cycle twice against max_failures.
+        if isinstance(response, list):
+            return response
 
         def json_func():
             data = response.json()
@@ -3159,6 +3337,16 @@ class PvInterface:
                     "[PV-IF] Timeseries endpoint returned unexpected data - "
                     "verify data_url and data_path in Settings > PV Source"
                 )
+
+        if source == "forecast_solar" and error_type == "rate_limit":
+            logger.error(
+                "[PV-IF] Forecast.Solar quota is metered per IP address, or per API key"
+                " once one is set. The public tier allows 12 requests/hour and EOS"
+                " Connect spends one per PV installation per cycle. Add an API key in"
+                " Settings > PV Source to raise the quota, or reduce the number of"
+                " installations. Requests stay paused until the reported retry time"
+                " passes - retrying sooner only restarts the block."
+            )
 
         logger.debug(
             "[PV-IF] Available PV sources: %s (current: %s, consecutive_failures: %d/%d)",

--- a/src/interfaces/pv_interface.py
+++ b/src/interfaces/pv_interface.py
@@ -2180,14 +2180,14 @@ class PvInterface:
                 "openmeteo_lib",
             )
 
-    def __forecast_solar_url(self, pv_config_entry):
+    def __forecast_solar_request_path(self, pv_config_entry):
         """
-        Build the Forecast.Solar estimate URL, plus a copy safe to log.
+        Build the keyless part of a Forecast.Solar estimate URL.
 
-        The API key is the first path segment rather than a header or query parameter
-        (https://doc.forecast.solar/api:estimate), and leaving it out selects the public
-        tier.  That also means logging the URL verbatim would write a credential into
-        the log file on every cycle, hence the second, redacted return value.
+        Deliberately knows nothing about the API key.  The key is the first path segment
+        rather than a header or query parameter (https://doc.forecast.solar/api:estimate),
+        so the caller prefixes it - and can log this suffix freely, because no credential
+        has ever been near it.
         """
         latitude = pv_config_entry["lat"]
         longitude = pv_config_entry["lon"]
@@ -2219,15 +2219,9 @@ class PvInterface:
                 horizon_forecast_solar_api * (24 // len(horizon_forecast_solar_api) + 1)
             )[:24]
 
-        api_key = str(self.config_source.get("api_key", "") or "").strip()
-        path = (
+        return (
             f"estimate/{latitude}/{longitude}/{tilt}/{azimuth}/{installed_power_watt}"
             f"?horizon={','.join(map(str, horizon_forecast_solar_api))}"
-        )
-        base = "https://api.forecast.solar/"
-        return (
-            f"{base}{api_key + '/' if api_key else ''}{path}",
-            f"{base}{'***/' if api_key else ''}{path}",
         )
 
     def __forecast_solar_retry_after_seconds(self, response):
@@ -2317,9 +2311,22 @@ class PvInterface:
             )
             return self.__forecast_solar_hold_response(pv_config_entry, hold_remaining)
 
-        url, redacted_url = self.__forecast_solar_url(pv_config_entry)
+        # The key is a path segment, so the request URL is a credential and must not be
+        # logged.  Build the two strings from the same keyless suffix rather than
+        # deriving the log line from the URL: nothing the key touches reaches the log,
+        # which is also what stops static analysis reading this as a leak.
+        request_path = self.__forecast_solar_request_path(pv_config_entry)
+        api_key = str(self.config_source.get("api_key", "") or "").strip()
+        if api_key:
+            url = f"https://api.forecast.solar/{api_key}/{request_path}"
+            loggable_url = f"https://api.forecast.solar/***/{request_path}"
+        else:
+            url = f"https://api.forecast.solar/{request_path}"
+            # Built again rather than aliased to ``url``: the two must never share a
+            # value, or the branch above leaks the key into the log by association.
+            loggable_url = f"https://api.forecast.solar/{request_path}"
         logger.debug(
-            "[PV-IF] Fetching PV forecast from Forecast.Solar API: %s", redacted_url
+            "[PV-IF] Fetching PV forecast from Forecast.Solar API: %s", loggable_url
         )
 
         def request_func():

--- a/tests/config_web/test_schema.py
+++ b/tests/config_web/test_schema.py
@@ -174,3 +174,40 @@ class TestConfigSchema:
         for field in [charge_from_grid, avoid_discharge, discharge_allowed]:
             assert "restart_required" in field.labels
 
+
+
+class TestPvForecastApiKey:
+    """The shared api_key field also serves Forecast.Solar (issue #288)."""
+
+    def setup_method(self):
+        """Create a fresh schema instance for each test."""
+        self.schema = ConfigSchema()
+
+    def test_api_key_is_offered_for_forecast_solar(self):
+        """Forecast.Solar takes a key as its first URL path segment, so expose it."""
+        field = self.schema.get("pv_forecast_source.api_key")
+        sources = field.depends_on["pv_forecast_source.source"]
+        assert set(sources) == {"solcast", "victron", "forecast_solar"}
+
+    def test_api_key_stays_a_password_field(self):
+        """It is a credential for every source that uses it."""
+        assert self.schema.get("pv_forecast_source.api_key").field_type == "password"
+
+    def test_api_key_is_not_required_for_forecast_solar(self):
+        """The public tier works without one, so the field must stay optional."""
+        field = self.schema.get("pv_forecast_source.api_key")
+        assert not (field.validation or {}).get("required")
+
+    def test_description_is_resolved_per_source(self):
+        """Each provider gets wording that says whether the key is required."""
+        resolve = self.schema.get_resolved_description
+        solcast = resolve(
+            "pv_forecast_source.api_key", {"pv_forecast_source.source": "solcast"}
+        )
+        forecast_solar = resolve(
+            "pv_forecast_source.api_key",
+            {"pv_forecast_source.source": "forecast_solar"},
+        )
+        assert "required" in solcast.lower()
+        assert "optional" in forecast_solar.lower()
+        assert forecast_solar != solcast

--- a/tests/interfaces/test_pv_interface_forecast_solar.py
+++ b/tests/interfaces/test_pv_interface_forecast_solar.py
@@ -1,0 +1,357 @@
+# pylint: disable=protected-access
+"""
+Tests for the Forecast.Solar PV source: API key support and 429 back-off.
+
+Forecast.Solar meters requests per zone - the caller's IP, or the API key once one is
+configured - and hands out 12 per hour on the public tier.  These tests pin the two
+behaviours that keep EOS Connect inside that budget: the key goes into the URL path (and
+nowhere near the log), and a 429 parks further requests instead of retrying into a
+permanent block.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+import pytest
+import requests
+
+from src.interfaces import pv_interface as pv_module
+from src.interfaces.pv_interface import (
+    FORECAST_SOLAR_DEFAULT_HOLD_S,
+    FORECAST_SOLAR_MAX_HOLD_S,
+    FORECAST_SOLAR_MIN_HOLD_S,
+    PvInterface,
+)
+
+TIME_FRAME_BASE = 3600
+
+
+@pytest.fixture(autouse=True)
+def patch_thread(monkeypatch):
+    """Keep the background update thread out of the tests."""
+
+    class DummyThread:
+        """Stand-in for threading.Thread that never runs anything."""
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            """No-op."""
+
+        def is_alive(self):
+            """Report dead so shutdown() never waits."""
+            return False
+
+        def join(self, timeout=None):
+            """No-op."""
+
+    monkeypatch.setattr("threading.Thread", DummyThread)
+
+
+def _installation(name="roof", power=5000):
+    return {
+        "name": name,
+        "lat": 50.0,
+        "lon": 8.0,
+        "azimuth": 0,
+        "tilt": 30,
+        "power": power,
+        "horizon": [0] * 24,
+    }
+
+
+def _make_pv(api_key="", installations=1):
+    config_source = {"source": "forecast_solar"}
+    if api_key:
+        config_source["api_key"] = api_key
+    config = [_installation(f"roof{i}") for i in range(installations)]
+    return PvInterface(config_source, config, TIME_FRAME_BASE, {}, timezone="UTC")
+
+
+class _MockResponse:
+    """Minimal stand-in for a requests.Response."""
+
+    def __init__(self, status_code=200, payload=None, headers=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.headers = headers or {}
+
+    def json(self):
+        """Return the canned payload."""
+        return self._payload
+
+    def raise_for_status(self):
+        """Mimic requests' behaviour for non-2xx codes."""
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"{self.status_code} error")
+
+
+def _success_payload():
+    """A watt_hours_period block covering 48 hours from a fixed midnight."""
+    start = datetime(2026, 3, 1, 0, 0, 0)
+    return {
+        "result": {
+            "watt_hours_period": {
+                (start + timedelta(hours=i)).strftime("%Y-%m-%d %H:%M:%S"): 100 * i
+                for i in range(48)
+            }
+        },
+        "message": {"ratelimit": {"period": 3600, "limit": 12, "remaining": 11}},
+    }
+
+
+def _capture_urls(monkeypatch, response):
+    """Patch requests.get to record every URL it is called with."""
+    urls = []
+
+    def mock_get(url, *_args, **_kwargs):
+        urls.append(url)
+        return response() if callable(response) else response
+
+    monkeypatch.setattr("requests.get", mock_get)
+    return urls
+
+
+# --------------------------------------------------------------------------- API key
+
+
+def test_url_has_no_key_segment_without_api_key(monkeypatch):
+    """Without a key the public-tier URL must be unchanged."""
+    pv = _make_pv()
+    urls = _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+
+    pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert len(urls) == 1
+    assert urls[0].startswith("https://api.forecast.solar/estimate/50.0/8.0/30/0/5.0")
+
+
+def test_api_key_is_the_first_path_segment(monkeypatch):
+    """The key goes before 'estimate', per doc.forecast.solar/api:estimate."""
+    pv = _make_pv(api_key="SECRETKEY123")
+    urls = _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+
+    pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert urls[0].startswith(
+        "https://api.forecast.solar/SECRETKEY123/estimate/50.0/8.0/30/0/5.0"
+    )
+
+
+def test_api_key_is_read_from_the_source_config_not_the_installation(monkeypatch):
+    """An api_key on the installation entry must be ignored - it lives on the source."""
+    pv = _make_pv(api_key="FROMSOURCE")
+    entry = dict(pv.config[0], api_key="FROMENTRY")
+    urls = _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+
+    pv._PvInterface__get_pv_forecast_forecast_solar_api(entry)
+
+    assert "FROMSOURCE" in urls[0]
+    assert "FROMENTRY" not in urls[0]
+
+
+def test_api_key_is_never_logged(monkeypatch, caplog):
+    """The key sits in the path, so the debug URL must be redacted."""
+    pv = _make_pv(api_key="SECRETKEY123")
+    _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+
+    with caplog.at_level(logging.DEBUG, logger="__main__"):
+        pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert "SECRETKEY123" not in caplog.text
+    assert "https://api.forecast.solar/***/estimate/" in caplog.text
+
+
+def test_blank_api_key_is_treated_as_absent(monkeypatch):
+    """Whitespace in the field must not produce a bogus '  /estimate' path."""
+    pv = _make_pv(api_key="   ")
+    urls = _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+
+    pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert urls[0].startswith("https://api.forecast.solar/estimate/")
+
+
+# ------------------------------------------------------------------------ 429 handling
+
+
+def test_429_arms_the_hold_and_makes_exactly_one_request(monkeypatch):
+    """
+    The bug behind "you can never get out of it": a 429 is a RequestException, so
+    _retry_request used to fire three requests against an exhausted quota.
+    """
+    pv = _make_pv()
+    urls = _capture_urls(monkeypatch, _MockResponse(status_code=429))
+
+    result = pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert len(urls) == 1
+    assert pv._forecast_solar_hold_until is not None
+    assert pv.pv_forcast_request_error["error"] == "rate_limit"
+    assert result == []
+
+
+def test_hold_skips_the_request_entirely(monkeypatch):
+    """While the hold stands, no HTTP call may be made at all."""
+    pv = _make_pv()
+    pv.last_successful_pv_forecast = [42] * 48
+    pv._forecast_solar_hold_until = datetime.now() + timedelta(seconds=600)
+    urls = _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+
+    result = pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert not urls
+    assert result == [42] * 48
+    assert pv.pv_forcast_request_error["error"] == "rate_limit"
+
+
+def test_hold_does_not_count_as_a_failure(monkeypatch):
+    """
+    Waiting out a quota is not a failed fetch.  Counting it would exhaust max_failures
+    and throw away the cache the hold exists to protect.
+    """
+    pv = _make_pv()
+    pv.last_successful_pv_forecast = [7] * 48
+    _capture_urls(monkeypatch, _MockResponse(status_code=429))
+
+    pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+    before = pv.consecutive_failures
+    for _ in range(5):
+        pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert pv.consecutive_failures == before == 0
+
+
+def test_requests_resume_once_the_hold_expires(monkeypatch):
+    """An expired hold must clear itself and let the next cycle through."""
+    pv = _make_pv()
+    pv._forecast_solar_hold_until = datetime.now() - timedelta(seconds=1)
+    urls = _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+
+    result = pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert len(urls) == 1
+    assert pv._forecast_solar_hold_until is None
+    assert len(result) == 48
+
+
+def test_reload_config_clears_the_hold():
+    """
+    Adding or removing the key moves us to a different quota zone, so a hold recorded
+    against the old one no longer describes anything real.
+    """
+    pv = _make_pv()
+    pv._forecast_solar_hold_until = datetime.now() + timedelta(seconds=3000)
+
+    pv.reload_config(
+        {"source": "forecast_solar", "api_key": "NEWKEY"},
+        [_installation()],
+        {},
+        False,
+        "UTC",
+    )
+
+    assert pv._forecast_solar_hold_until is None
+
+
+# ------------------------------------------------------- retry-after parsing
+
+
+@pytest.mark.parametrize(
+    "headers,payload,expected",
+    [
+        ({"Retry-After": "900"}, {}, 900),
+        ({"X-Ratelimit-Reset": "1200"}, {}, 1200),
+        # Header wins over the body: it is the more specific answer.
+        ({"Retry-After": "300"}, {"message": {"ratelimit": {"reset": 1800}}}, 300),
+        ({}, {"message": {"ratelimit": {"reset": 1800}}}, 1800),
+        # Nothing usable at all falls back to the public tier's own period.
+        ({}, {}, FORECAST_SOLAR_DEFAULT_HOLD_S),
+        ({}, {"message": {"ratelimit": {}}}, FORECAST_SOLAR_DEFAULT_HOLD_S),
+        # Garbage must not raise out of the error path.
+        ({"Retry-After": "soon"}, {"message": "not a dict"}, FORECAST_SOLAR_DEFAULT_HOLD_S),
+        # Out-of-range values are clamped rather than trusted.
+        ({"Retry-After": "5"}, {}, FORECAST_SOLAR_MIN_HOLD_S),
+        ({"Retry-After": "999999"}, {}, FORECAST_SOLAR_MAX_HOLD_S),
+    ],
+)
+def test_retry_after_parsing(headers, payload, expected):
+    """Every documented signal is read, and anything unusable degrades safely."""
+    pv = _make_pv()
+    response = _MockResponse(status_code=429, payload=payload, headers=headers)
+
+    hold = pv._PvInterface__forecast_solar_retry_after_seconds(response)
+
+    assert hold == expected
+
+
+def test_retry_at_timestamp_is_honoured():
+    """The ISO 'retry-at' the API returns is converted to a hold in seconds."""
+    pv = _make_pv()
+    retry_at = (datetime.now() + timedelta(seconds=750)).isoformat()
+    response = _MockResponse(
+        status_code=429, payload={"message": {"ratelimit": {"retry-at": retry_at}}}
+    )
+
+    hold = pv._PvInterface__forecast_solar_retry_after_seconds(response)
+
+    assert 700 <= hold <= 760
+
+
+def test_a_body_that_cannot_be_parsed_still_yields_a_hold():
+    """A 429 with an unreadable body must still stop us calling."""
+    pv = _make_pv()
+
+    class Broken(_MockResponse):
+        """Response whose body cannot be decoded."""
+
+        def json(self):
+            raise ValueError("not json")
+
+    hold = pv._PvInterface__forecast_solar_retry_after_seconds(Broken(status_code=429))
+
+    assert hold == FORECAST_SOLAR_DEFAULT_HOLD_S
+
+
+# ------------------------------------------------------------------- auth + interval
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_rejected_api_key_reports_an_actionable_error(monkeypatch, status):
+    """A bad key must not surface as a bare HTTPError."""
+    pv = _make_pv(api_key="WRONG")
+    monkeypatch.setattr(pv_module.time, "sleep", lambda _s: None)
+    _capture_urls(monkeypatch, _MockResponse(status_code=status))
+
+    pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    message = str(pv.pv_forcast_request_error["message"])
+    assert pv.pv_forcast_request_error["error"] == "request_failed"
+    assert "rejected the API key" in message
+    assert "WRONG" not in message
+
+
+@pytest.mark.parametrize(
+    "installations,expected_seconds", [(1, 900), (2, 1800), (3, 2700), (4, 3600)]
+)
+def test_update_interval_scales_with_the_installation_count(
+    installations, expected_seconds
+):
+    """
+    One request per plane per cycle against a 12/hour budget: scaling the interval
+    keeps total traffic at four requests an hour however many planes are configured.
+    """
+    pv = _make_pv(installations=installations)
+
+    assert pv.update_interval == expected_seconds
+
+
+def test_other_sources_keep_the_flat_interval():
+    """The scaling must not leak into providers that batch their planes."""
+    config = [_installation(f"roof{i}") for i in range(3)]
+    pv = PvInterface(
+        {"source": "akkudoktor"}, config, TIME_FRAME_BASE, {}, timezone="UTC"
+    )
+
+    assert pv.update_interval == 15 * 60

--- a/tests/interfaces/test_pv_interface_forecast_solar.py
+++ b/tests/interfaces/test_pv_interface_forecast_solar.py
@@ -152,15 +152,35 @@ def test_api_key_is_read_from_the_source_config_not_the_installation(monkeypatch
 
 
 def test_api_key_is_never_logged(monkeypatch, caplog):
-    """The key sits in the path, so the debug URL must be redacted."""
+    """
+    The key sits in the URL path, so the request carries it and the log must not.
+    Both halves are asserted together: that divergence is the whole point.
+    """
     pv = _make_pv(api_key="SECRETKEY123")
-    _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+    urls = _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
 
     with caplog.at_level(logging.DEBUG, logger="__main__"):
         pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
 
+    assert "SECRETKEY123" in urls[0]
     assert "SECRETKEY123" not in caplog.text
     assert "https://api.forecast.solar/***/estimate/" in caplog.text
+
+
+def test_nothing_logged_at_all_carries_the_key(monkeypatch, caplog):
+    """
+    Belt and braces across every log level, including the error paths: no record
+    emitted by a Forecast.Solar cycle may contain the credential.
+    """
+    pv = _make_pv(api_key="SECRETKEY123")
+    _capture_urls(monkeypatch, _MockResponse(status_code=429))
+
+    with caplog.at_level(logging.DEBUG, logger="__main__"):
+        pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+        pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert "SECRETKEY123" not in caplog.text
+    assert "SECRETKEY123" not in str(pv.pv_forcast_request_error)
 
 
 def test_blank_api_key_is_treated_as_absent(monkeypatch):

--- a/tests/interfaces/test_pv_interface_forecast_solar.py
+++ b/tests/interfaces/test_pv_interface_forecast_solar.py
@@ -167,6 +167,27 @@ def test_api_key_is_never_logged(monkeypatch, caplog):
     assert "https://api.forecast.solar/***/estimate/" in caplog.text
 
 
+def test_coordinates_are_never_logged(monkeypatch, caplog):
+    """
+    The coordinates are the user's home address to within metres, and the bug reporter
+    offers to paste recent log lines into a public GitHub issue. The request must carry
+    them; the log must not.
+    """
+    pv = _make_pv()
+    urls = _capture_urls(monkeypatch, _MockResponse(payload=_success_payload()))
+
+    with caplog.at_level(logging.DEBUG, logger="__main__"):
+        pv._PvInterface__get_pv_forecast_forecast_solar_api(pv.config[0])
+
+    assert "50.0/8.0" in urls[0]
+    assert "50.0" not in caplog.text
+    assert "8.0" not in caplog.text
+    assert "estimate/<lat>/<lon>/" in caplog.text
+    # The parameters that actually help diagnose a bad request still survive.
+    assert "/30/0/5.0?horizon=" in caplog.text
+    assert "roof0" in caplog.text
+
+
 def test_nothing_logged_at_all_carries_the_key(monkeypatch, caplog):
     """
     Belt and braces across every log level, including the error paths: no record
@@ -181,6 +202,8 @@ def test_nothing_logged_at_all_carries_the_key(monkeypatch, caplog):
 
     assert "SECRETKEY123" not in caplog.text
     assert "SECRETKEY123" not in str(pv.pv_forcast_request_error)
+    assert "50.0" not in caplog.text
+    assert "8.0" not in caplog.text
 
 
 def test_blank_api_key_is_treated_as_absent(monkeypatch):


### PR DESCRIPTION
The estimate endpoint takes the key as its first path segment, so a Personal or Professional account could not be used at all: the URL was hardcoded to the public form and the api_key field was gated to Solcast and Victron.

A key alone would not have helped, because the quota zone is the IP *or* the key. Every rate-limited cycle fired three requests, since a 429 is a RequestException and _retry_request retries those, and the poll interval ignored that one request is made per PV installation - three planes hit the public tier's 12/hour ceiling on the happy path alone. Users ended up holding themselves in the block indefinitely.

The 429 is now read for its retry-at and suppresses calls until it expires, the interval scales with the plane count, and the key is kept out of the debug log it would otherwise be printed into.

Fixes: #288